### PR TITLE
API Discovery: auth-parameters API + default list + 35-day retention

### DIFF
--- a/docs/latest/api-discovery/authentication.md
+++ b/docs/latest/api-discovery/authentication.md
@@ -8,7 +8,7 @@ You can use the **Authentication** filter in the API Discovery inventory to quic
 
 ## Requirements
 
-Authentication flow detection is supported starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.10.0 and [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.23.0.
+Authentication flow detection is supported starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.11.0 and [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.23.0.
 
 ## Detected authentication types
 
@@ -57,3 +57,95 @@ In the **Authentication** tab of the endpoint details, Wallarm lists every detec
 | **Path** | Hierarchical location of the parameter within the request structure. |
 
 A single endpoint can have multiple authentication parameters. For example, one endpoint might use a Bearer token in the `Authorization` header for 80% of requests and an API key in the body for 5%. Each parameter's coverage is calculated independently — coverages may not add up to 100%.
+
+## Customizing detected authentication parameters
+
+If your APIs use authentication parameters that are not part of the [recognized set](#detected-authentication-types) above — for example, a custom header, a non-standard cookie name, or a token field in the request body — you can extend the per-tenant detection list through the Wallarm API. After a parameter is added, requests carrying it are counted as authenticated when calculating endpoint authentication status, coverage, and the **Authentication** filter.
+
+The configuration is per client (tenant). Changes affect only the client whose ID is in the request path.
+
+### Default detection parameters
+
+In addition to the [recognized authentication types](#detected-authentication-types) above, Wallarm ships a curated list of common authentication parameter names that are detected automatically — no configuration needed. The list was assembled from cross-tenant analysis of real production traffic and rolled out to all clients running an upgraded node.
+
+The defaults cover **34 parameter points** grouped by request location:
+
+| Location | Parameter names |
+| --- | --- |
+| HTTP headers | `APIKEY`, `CLIENT_SECRET`, `JWT`, `OCP-APIM-SUBSCRIPTION-KEY`, `X-SECRET`, `X-TOKEN` |
+| Cookies | `access-token`, `access_token`, `auth-token`, `Authorization`, `jwt`, `KEYCLOAK_IDENTITY`, `refresh_token`, `session-token` |
+| Query string | `access_token`, `api_key`, `apiKey`, `apikey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
+| Form-encoded body (`application/x-www-form-urlencoded`) | `access_token`, `api_key`, `apiKey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
+| JSON body (`application/json`) | `access_token`, `api_key`, `apiKey`, `client_secret`, `refresh_token` |
+
+Header names are matched case-insensitively. Cookie, query, and body parameter names are matched as written — different casings (`apiKey`, `apikey`, `APIKEY`) are listed separately because real APIs use them inconsistently.
+
+If your APIs use parameter names that fall outside this list, extend the per-tenant configuration as described below.
+
+### Reviewing the current configuration
+
+To retrieve the parameters currently in effect for a client, send a `GET` request:
+
+=== "US Cloud"
+    ``` bash
+    curl -X GET \
+      'https://us1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
+    ```
+=== "EU Cloud"
+    ``` bash
+    curl -X GET \
+      'https://api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
+    ```
+=== "ME Cloud"
+    ``` bash
+    curl -X GET \
+      'https://me1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
+    ```
+
+The response lists every authentication parameter that the tenant currently treats as a valid authentication signal — the recognized defaults plus any custom entries previously added.
+
+### Adding a new authentication parameter
+
+To register a parameter, send a `POST` request describing where the parameter sits in a request. The location is described by a `point` array — a hierarchical path that mirrors how Wallarm parses a request:
+
+| Location | `point` shape | Example |
+| --- | --- | --- |
+| HTTP header | `["header", "<HEADER_NAME>"]` | `["header", "X-API-KEY"]` |
+| Cookie | `["header", "COOKIE", "cookie", "<COOKIE_NAME>"]` | `["header", "COOKIE", "cookie", "session"]` |
+| Query string | `["get", "<PARAM_NAME>"]` | `["get", "access_token"]` |
+| Form-encoded body field | `["post", "form_urlencoded", "<FIELD_NAME>"]` | `["post", "form_urlencoded", "client_secret"]` |
+| JSON body field | `["post", "json_doc", "json_obj", "<FIELD_NAME>"]` | `["post", "json_doc", "json_obj", "refresh_token"]` |
+
+Header names in the `point` array are written in uppercase and are matched case-insensitively against incoming requests. Query and body field names preserve case as written.
+
+=== "US Cloud"
+    ``` bash
+    curl -X POST \
+      'https://us1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>' \
+      -H 'Content-Type: application/json' \
+      -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
+    ```
+=== "EU Cloud"
+    ``` bash
+    curl -X POST \
+      'https://api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>' \
+      -H 'Content-Type: application/json' \
+      -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
+    ```
+=== "ME Cloud"
+    ``` bash
+    curl -X POST \
+      'https://me1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>' \
+      -H 'Content-Type: application/json' \
+      -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
+    ```
+
+The endpoint accepts **one parameter per request**. To register multiple parameters, send a separate `POST` for each one. Use the `GET` call above to review the current list and avoid duplicates.
+
+After a parameter is added, authentication coverage is recalculated for new traffic. Existing endpoints transition between [authentication statuses](#authentication-status) on the same 7-day observation window.

--- a/docs/latest/api-discovery/track-changes.md
+++ b/docs/latest/api-discovery/track-changes.md
@@ -28,6 +28,9 @@ In the **Status** column for endpoints and parameters, API Discovery provides da
 
     * If later the endpoint in the `Unused` status is requested (with the code 200 in response) again it will lose the `Unused` status.
 
+!!! warning "Unused endpoints are removed after 35 days"
+    Endpoints that receive no qualifying requests for **35 days** since their last update are automatically removed from your API inventory, together with their parameters, sensitive-data history, authentication coverage, and risk-score evolution. **Removed entries cannot be restored.** If traffic to such an endpoint resumes later, the endpoint reappears as **New** and discovery starts over from scratch — past parameter information and history are not recovered.
+
 ![API Discovery - track changes](../images/about-wallarm-waf/api-discovery-2.0/api-discovery-changes.png)
 
 Use **Changed since** filter to only see endpoints changed in specific time period, for example, today.


### PR DESCRIPTION
Three updates to the **API Discovery** section, fixing one factual error and filling two long-standing documentation gaps that customers and CE keep hitting.

## Changes

### `authentication.md`

- **Version fix.** NGINX Node minimum for authentication flow detection corrected from `6.10.0` to `6.11.0`. Native Node `0.23.0` is unchanged.
- **New section: Customizing detected authentication parameters.** Documents the per-tenant `/v1/clients/<CLIENT_ID>/apid/config/auth-parameters` API:
  - `GET` to review the active list.
  - `POST` to register a new parameter, with the `point`-array shapes for header / cookie / query / form-encoded / JSON-body locations.
  - One-parameter-per-request constraint.
  - Per-cloud (`US` / `EU` / `ME`) curl examples in tabbed code blocks.
- **New subsection: Default detection parameters.** Lists the **34 default parameter names** that are detected automatically on all upgraded-node clients, grouped by location (header, cookie, query, form-encoded, JSON body), with a note on case-sensitivity.

### `track-changes.md`

- **New warning admonition** placed immediately after the **Unused** status bullet:
  > Endpoints with no qualifying requests for 35 days since their last update are automatically removed from the inventory and cannot be restored — re-discovery starts over and prior parameter / sensitive-data / authentication / risk-score history is not recovered.

## Why

- The `auth-parameters` API is already used by the security research team to extend tenant detection for non-standard schemes (OCP-APIM, Keycloak cookies, custom JWTs, …). Without docs, customers cannot self-serve.
- The 35-day retention surprises customers who expect their full history to remain available indefinitely.
- The `6.10.0` minimum was a misstatement; actual minimum is `6.11.0`.

## Validation

- Style checked against the `docs/latest/api-discovery/` conventions (American English, no contractions, second person, present tense, `<UPPERCASE_WITH_UNDERSCORES>` placeholders).
- Source for the 34-entry default list: cross-tenant traffic analysis (2026-04-23) applied via the internal `apply-auth-params.py` tooling to all upgraded-node tenants.
- Source for 35-day TTL: behavior of `api-discovery-server` against the `updated` timestamp.

Please double-check the table rendering in the **Default detection parameters** subsection on the Netlify preview.