### PR TITLE
API Discovery: auth-parameters API + default list + 35-day retention

### DIFF
--- a/docs/6.x/updating-migrating/node-artifact-versions.md
+++ b/docs/6.x/updating-migrating/node-artifact-versions.md
@@ -50,6 +50,7 @@ new attack types in logging variables and search bars?
 
 ### 6.11.0 (2026-03-25)
 
+* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Fixed empty response (`000` status code) instead of [custom block page](../admin-en/configuration-guides/configure-block-page-and-code.md) when [`ngx_http_auth_request_module`](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) is used
 * Fixed the [GHSA-6g7g-w4f8-9c9x](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x) vulnerability
 * Bumped Go version to 1.26.1
@@ -77,7 +78,6 @@ new attack types in logging variables and search bars?
 
 ### 6.10.0 (2026-02-09)
 
-* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Added support for NGINX stable 1.28.2
 * Fixed an issue where the Node sent too many requests in a single batch to **wstore**, causing submission failures
@@ -279,6 +279,7 @@ new attack types in logging variables and search bars?
 
 ### 6.11.1 (2026-03-25)
 
+* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Upgraded to Community Ingress NGINX Controller version [1.15.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.15.0), aligning with the upstream Helm chart version 4.15.0
 
     The underlying NGINX has been updated to 1.27.1 and the base Alpine image to 3.23.3.
@@ -311,7 +312,6 @@ new attack types in logging variables and search bars?
 
 ### 6.10.0 (2026-02-09)
 
-* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Fixed an issue where the Node sent too many requests in a single batch to **wstore**, causing submission failures
 
@@ -517,6 +517,7 @@ new attack types in logging variables and search bars?
 
 ### 6.11.1 (2026-03-25)
 
+* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Fixed empty response (`000` status code) instead of [custom block page](../admin-en/configuration-guides/configure-block-page-and-code.md) when [`ngx_http_auth_request_module`](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) is used
 * Fixed the [GHSA-6g7g-w4f8-9c9x](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x) vulnerability
 * Bumped Go version to 1.26.1
@@ -544,7 +545,6 @@ new attack types in logging variables and search bars?
 
 ### 6.10.0 (2026-02-09)
 
-* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Fixed an issue where the Node sent too many requests in a single batch to **wstore**, causing submission failures
 
@@ -734,6 +734,7 @@ new attack types in logging variables and search bars?
 
 ### 6.11.1 (2026-03-25)
 
+* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Fixed empty response (`000` status code) instead of [custom block page](../admin-en/configuration-guides/configure-block-page-and-code.md) when [`ngx_http_auth_request_module`](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) is used
 * Fixed the [GHSA-6g7g-w4f8-9c9x](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x) vulnerability
 * Bumped Go version to 1.26.1
@@ -761,7 +762,6 @@ new attack types in logging variables and search bars?
 
 ### 6.10.0 (2026-02-09)
 
-* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Fixed an issue where the Node sent too many requests in a single batch to **wstore**, causing submission failures
 
@@ -948,6 +948,7 @@ new attack types in logging variables and search bars?
 
 ### 6.11.1 (2026-03-25)
 
+* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Fixed empty response (`000` status code) instead of [custom block page](../admin-en/configuration-guides/configure-block-page-and-code.md) when [`ngx_http_auth_request_module`](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) is used
 * Fixed the [GHSA-6g7g-w4f8-9c9x](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x) vulnerability
 * Bumped Go version to 1.26.1
@@ -975,7 +976,6 @@ new attack types in logging variables and search bars?
 
 ### 6.10.0 (2026-02-09)
 
-* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Fixed an issue where the Node sent too many requests in a single batch to **wstore**, causing submission failures
 
@@ -1131,6 +1131,7 @@ new attack types in logging variables and search bars?
 
 ### wallarm-node-6-11-1-20260325-092834 (2026-03-25)
 
+* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Fixed empty response (`000` status code) instead of [custom block page](../admin-en/configuration-guides/configure-block-page-and-code.md) when [`ngx_http_auth_request_module`](https://nginx.org/en/docs/http/ngx_http_auth_request_module.html) is used
 * Fixed the [GHSA-6g7g-w4f8-9c9x](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x) vulnerability
 * Bumped Go version to 1.26.1
@@ -1158,7 +1159,6 @@ new attack types in logging variables and search bars?
 
 ### wallarm-node-6-10-0-20260206-084755 (2026-02-09)
 
-* Added [authentication flow detection](../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Fixed an issue where the Node sent too many requests in a single batch to **wstore**, causing submission failures
 

--- a/docs/latest/api-discovery/authentication.md
+++ b/docs/latest/api-discovery/authentication.md
@@ -8,9 +8,9 @@ You can use the **Authentication** filter in the API Discovery inventory to quic
 
 ## Requirements
 
-Authentication flow detection is supported starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.11.0 and [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.23.0.
+Authentication flow detection is supported starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.11.0 and [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.24.0.
 
-## Detected authentication types
+## Default authentication types
 
 Wallarm recognizes the following authentication types:
 
@@ -29,6 +29,24 @@ Wallarm recognizes the following authentication types:
 | **SCRAM** | Salted Challenge Response Authentication Mechanism. |
 
 An endpoint can have multiple authentication types if different requests use different authentication mechanisms.
+
+## Default authentication parameters
+
+In addition to the recognized authentication types above, Wallarm ships a curated list of common authentication parameter names that are detected automatically — no configuration needed.
+
+The defaults cover the following request points grouped by request location:
+
+| Location | Parameter names |
+| --- | --- |
+| HTTP headers | `APIKEY`, `CLIENT_SECRET`, `JWT`, `OCP-APIM-SUBSCRIPTION-KEY`, `X-SECRET`, `X-TOKEN` |
+| Cookies | `access-token`, `access_token`, `auth-token`, `Authorization`, `jwt`, `KEYCLOAK_IDENTITY`, `refresh_token`, `session-token` |
+| Query string | `access_token`, `api_key`, `apiKey`, `apikey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
+| Form-encoded body (`application/x-www-form-urlencoded`) | `access_token`, `api_key`, `apiKey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
+| JSON body (`application/json`) | `access_token`, `api_key`, `apiKey`, `client_secret`, `refresh_token` |
+
+Header names are matched case-insensitively. Cookie, query, and body parameter names are matched as written — different casings (`apiKey`, `apikey`, `APIKEY`) are listed separately because real APIs use them inconsistently.
+
+If your APIs use parameter names that fall outside this list, you can [extend the per-tenant configuration](#customizing-detected-authentication-parameters).
 
 ## Authentication status
 
@@ -60,27 +78,9 @@ A single endpoint can have multiple authentication parameters. For example, one 
 
 ## Customizing detected authentication parameters
 
-If your APIs use authentication parameters that are not part of the [recognized set](#detected-authentication-types) above — for example, a custom header, a non-standard cookie name, or a token field in the request body — you can extend the per-tenant detection list through the Wallarm API. After a parameter is added, requests carrying it are counted as authenticated when calculating endpoint authentication status, coverage, and the **Authentication** filter.
+If your APIs use authentication parameters that are not part of the [default parameters](#default-authentication-parameters) — for example, a custom header, a non-standard cookie name, or a token field in the request body — you can extend the per-tenant detection list through the Wallarm API. After a parameter is added, requests carrying it are counted as authenticated when calculating endpoint authentication status, coverage, and the **Authentication** filter.
 
 The configuration is per client (tenant). Changes affect only the client whose ID is in the request path.
-
-### Default detection parameters
-
-In addition to the [recognized authentication types](#detected-authentication-types) above, Wallarm ships a curated list of common authentication parameter names that are detected automatically — no configuration needed. The list was assembled from cross-tenant analysis of real production traffic and rolled out to all clients running an upgraded node.
-
-The defaults cover **34 parameter points** grouped by request location:
-
-| Location | Parameter names |
-| --- | --- |
-| HTTP headers | `APIKEY`, `CLIENT_SECRET`, `JWT`, `OCP-APIM-SUBSCRIPTION-KEY`, `X-SECRET`, `X-TOKEN` |
-| Cookies | `access-token`, `access_token`, `auth-token`, `Authorization`, `jwt`, `KEYCLOAK_IDENTITY`, `refresh_token`, `session-token` |
-| Query string | `access_token`, `api_key`, `apiKey`, `apikey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
-| Form-encoded body (`application/x-www-form-urlencoded`) | `access_token`, `api_key`, `apiKey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
-| JSON body (`application/json`) | `access_token`, `api_key`, `apiKey`, `client_secret`, `refresh_token` |
-
-Header names are matched case-insensitively. Cookie, query, and body parameter names are matched as written — different casings (`apiKey`, `apikey`, `APIKEY`) are listed separately because real APIs use them inconsistently.
-
-If your APIs use parameter names that fall outside this list, extend the per-tenant configuration as described below.
 
 ### Reviewing the current configuration
 
@@ -104,6 +104,8 @@ To retrieve the parameters currently in effect for a client, send a `GET` reques
       'https://me1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
       -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
     ```
+
+Learn how to get an [API token](../api/overview/#your-own-api-client).
 
 The response lists every authentication parameter that the tenant currently treats as a valid authentication signal — the recognized defaults plus any custom entries previously added.
 
@@ -145,7 +147,11 @@ Header names in the `point` array are written in uppercase and are matched case-
       -H 'Content-Type: application/json' \
       -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
     ```
+    
+Learn how to get an [API token](../api/overview/#your-own-api-client).
 
 The endpoint accepts **one parameter per request**. To register multiple parameters, send a separate `POST` for each one. Use the `GET` call above to review the current list and avoid duplicates.
 
 After a parameter is added, authentication coverage is recalculated for new traffic. Existing endpoints transition between [authentication statuses](#authentication-status) on the same 7-day observation window.
+
+The [authentication type](#default-authentication-types) for a custom parameter is determined by analyzing the parameter value.

--- a/docs/latest/api-discovery/authentication.md
+++ b/docs/latest/api-discovery/authentication.md
@@ -8,7 +8,7 @@ You can use the **Authentication** filter in the API Discovery inventory to quic
 
 ## Requirements
 
-Authentication flow detection is supported starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.10.0 and [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.23.0.
+Authentication flow detection is supported starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.11.0 and [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.23.0.
 
 ## Detected authentication types
 
@@ -57,3 +57,95 @@ In the **Authentication** tab of the endpoint details, Wallarm lists every detec
 | **Path** | Hierarchical location of the parameter within the request structure. |
 
 A single endpoint can have multiple authentication parameters. For example, one endpoint might use a Bearer token in the `Authorization` header for 80% of requests and an API key in the body for 5%. Each parameter's coverage is calculated independently — coverages may not add up to 100%.
+
+## Customizing detected authentication parameters
+
+If your APIs use authentication parameters that are not part of the [recognized set](#detected-authentication-types) above — for example, a custom header, a non-standard cookie name, or a token field in the request body — you can extend the per-tenant detection list through the Wallarm API. After a parameter is added, requests carrying it are counted as authenticated when calculating endpoint authentication status, coverage, and the **Authentication** filter.
+
+The configuration is per client (tenant). Changes affect only the client whose ID is in the request path.
+
+### Default detection parameters
+
+In addition to the [recognized authentication types](#detected-authentication-types) above, Wallarm ships a curated list of common authentication parameter names that are detected automatically — no configuration needed. The list was assembled from cross-tenant analysis of real production traffic and rolled out to all clients running an upgraded node.
+
+The defaults cover **34 parameter points** grouped by request location:
+
+| Location | Parameter names |
+| --- | --- |
+| HTTP headers | `APIKEY`, `CLIENT_SECRET`, `JWT`, `OCP-APIM-SUBSCRIPTION-KEY`, `X-SECRET`, `X-TOKEN` |
+| Cookies | `access-token`, `access_token`, `auth-token`, `Authorization`, `jwt`, `KEYCLOAK_IDENTITY`, `refresh_token`, `session-token` |
+| Query string | `access_token`, `api_key`, `apiKey`, `apikey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
+| Form-encoded body (`application/x-www-form-urlencoded`) | `access_token`, `api_key`, `apiKey`, `Authorization`, `authorization`, `client_secret`, `refresh_token` |
+| JSON body (`application/json`) | `access_token`, `api_key`, `apiKey`, `client_secret`, `refresh_token` |
+
+Header names are matched case-insensitively. Cookie, query, and body parameter names are matched as written — different casings (`apiKey`, `apikey`, `APIKEY`) are listed separately because real APIs use them inconsistently.
+
+If your APIs use parameter names that fall outside this list, extend the per-tenant configuration as described below.
+
+### Reviewing the current configuration
+
+To retrieve the parameters currently in effect for a client, send a `GET` request:
+
+=== "US Cloud"
+    ``` bash
+    curl -X GET \
+      'https://us1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
+    ```
+=== "EU Cloud"
+    ``` bash
+    curl -X GET \
+      'https://api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
+    ```
+=== "ME Cloud"
+    ``` bash
+    curl -X GET \
+      'https://me1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>'
+    ```
+
+The response lists every authentication parameter that the tenant currently treats as a valid authentication signal — the recognized defaults plus any custom entries previously added.
+
+### Adding a new authentication parameter
+
+To register a parameter, send a `POST` request describing where the parameter sits in a request. The location is described by a `point` array — a hierarchical path that mirrors how Wallarm parses a request:
+
+| Location | `point` shape | Example |
+| --- | --- | --- |
+| HTTP header | `["header", "<HEADER_NAME>"]` | `["header", "X-API-KEY"]` |
+| Cookie | `["header", "COOKIE", "cookie", "<COOKIE_NAME>"]` | `["header", "COOKIE", "cookie", "session"]` |
+| Query string | `["get", "<PARAM_NAME>"]` | `["get", "access_token"]` |
+| Form-encoded body field | `["post", "form_urlencoded", "<FIELD_NAME>"]` | `["post", "form_urlencoded", "client_secret"]` |
+| JSON body field | `["post", "json_doc", "json_obj", "<FIELD_NAME>"]` | `["post", "json_doc", "json_obj", "refresh_token"]` |
+
+Header names in the `point` array are written in uppercase and are matched case-insensitively against incoming requests. Query and body field names preserve case as written.
+
+=== "US Cloud"
+    ``` bash
+    curl -X POST \
+      'https://us1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>' \
+      -H 'Content-Type: application/json' \
+      -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
+    ```
+=== "EU Cloud"
+    ``` bash
+    curl -X POST \
+      'https://api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>' \
+      -H 'Content-Type: application/json' \
+      -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
+    ```
+=== "ME Cloud"
+    ``` bash
+    curl -X POST \
+      'https://me1.api.wallarm.com/v1/clients/<CLIENT_ID>/apid/config/auth-parameters' \
+      -H 'X-WallarmApi-Token: <YOUR_TOKEN>' \
+      -H 'Content-Type: application/json' \
+      -d '{"point": [["header", "X-CUSTOM-AUTH"]]}'
+    ```
+
+The endpoint accepts **one parameter per request**. To register multiple parameters, send a separate `POST` for each one. Use the `GET` call above to review the current list and avoid duplicates.
+
+After a parameter is added, authentication coverage is recalculated for new traffic. Existing endpoints transition between [authentication statuses](#authentication-status) on the same 7-day observation window.

--- a/docs/latest/api-discovery/track-changes.md
+++ b/docs/latest/api-discovery/track-changes.md
@@ -28,6 +28,9 @@ In the **Status** column for endpoints and parameters, API Discovery provides da
 
     * If later the endpoint in the `Unused` status is requested (with the code 200 in response) again it will lose the `Unused` status.
 
+!!! warning "Unused endpoints are removed after 35 days"
+    Endpoints that receive no qualifying requests for **35 days** since their last update are automatically removed from your API inventory, together with their parameters, sensitive-data history, authentication coverage, and risk-score evolution. **Removed entries cannot be restored.** If traffic to such an endpoint resumes later, the endpoint reappears as **New** and discovery starts over from scratch — past parameter information and history are not recovered.
+
 ![API Discovery - track changes](../images/about-wallarm-waf/api-discovery-2.0/api-discovery-changes.png)
 
 Use **Changed since** filter to only see endpoints changed in specific time period, for example, today.

--- a/docs/latest/updating-migrating/native-node/node-artifact-versions.md
+++ b/docs/latest/updating-migrating/native-node/node-artifact-versions.md
@@ -25,6 +25,7 @@ History of all-in-one installer updates simultaneously applies to it's x86_64 an
 
 ### 0.24.0 (2026-04-06)
 
+* Added [authentication flow detection](../../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * [TCP traffic mirror analysis](../../installation/oob/tcp-traffic-mirror/deployment.md) (`tcp-capture-v2` mode):
 
     * Added support for [VXLAN](../../installation/oob/tcp-traffic-mirror/deployment.md#vxlan) and [GENEVE](../../installation/oob/tcp-traffic-mirror/deployment.md#geneve) decapsulation, including automatic support for [AWS VPC Traffic Mirroring](https://docs.aws.amazon.com/vpc/latest/mirroring/what-is-traffic-mirroring.html) (GENEVE with nested VXLAN)
@@ -83,7 +84,6 @@ History of all-in-one installer updates simultaneously applies to it's x86_64 an
 
 ### 0.23.0 (2026-02-24)
 
-* Added [authentication flow detection](../../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for circular references in OpenAPI specifications uploaded for [API Specification Enforcement](../../api-specification-enforcement/overview.md)
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Increased the frequency of session updates sent to the Wallarm Cloud. Sessions now appear in the UI faster, closer to real time
@@ -262,6 +262,7 @@ The Helm chart for the Native Node is used for self-hosted node deployments with
 
 ### 0.24.0 (2026-04-06)
 
+* Added [authentication flow detection](../../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Fixed [API Specification Enforcement](../../api-specification-enforcement/overview.md) not triggering [specification processing overlimit](../../api-specification-enforcement/viewing-events.md#overlimit-events) events for requests exceeding size or time limits
 * Updated [Prometheus metrics](../../admin-en/native-node-metrics-gonode.md):
 
@@ -300,7 +301,6 @@ The Helm chart for the Native Node is used for self-hosted node deployments with
 
 ### 0.23.0 (2026-02-24)
 
-* Added [authentication flow detection](../../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Improved the Helm chart for high-availability deployments by adding pod disruption budgets, tuning resource settings, and introducing the [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and [`startupProbe`](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#startup-probe) values
 * Added support for circular references in OpenAPI specifications uploaded for [API Specification Enforcement](../../api-specification-enforcement/overview.md)
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
@@ -493,6 +493,7 @@ The Docker image for the Native Node is used for self-hosted node deployment wit
 
 ### 0.24.0 (2026-04-06)
 
+* Added [authentication flow detection](../../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Changed default [`log.proton_log_mask`](../../installation/native-node/all-in-one-conf.md#logproton_log_mask) from `info@*` to `info+@*` to show warning and error messages from the traffic analysis engine (previously only info-level messages were displayed)
 * Changed default [`http_inspector.shm_dir`](../../installation/native-node/all-in-one-conf.md#http_inspectorshm_dir) from `/tmp` to `/opt/wallarm/shm` for better compatibility with containerized environments
 * Fixed [API Specification Enforcement](../../api-specification-enforcement/overview.md) not triggering [specification processing overlimit](../../api-specification-enforcement/viewing-events.md#overlimit-events) events for requests exceeding size or time limits
@@ -534,7 +535,6 @@ The Docker image for the Native Node is used for self-hosted node deployment wit
 
 ### 0.23.0 (2026-02-24)
 
-* Added [authentication flow detection](../../api-discovery/authentication.md) in API Discovery — automatically identifies authentication methods used by each endpoint and highlights unauthenticated endpoints
 * Added support for circular references in OpenAPI specifications uploaded for [API Specification Enforcement](../../api-specification-enforcement/overview.md)
 * Added support for OpenAPI v3 specifications with non-string (for example, integer) YAML keys in [API Specification Enforcement](../../api-specification-enforcement/overview.md). This improves compatibility and prevents schema parsing failures
 * Increased the frequency of session updates sent to the Wallarm Cloud. Sessions now appear in the UI faster, closer to real time


### PR DESCRIPTION
Three updates to the **API Discovery** section, fixing one factual error and filling two long-standing documentation gaps that customers and CE keep hitting.

> Re-opening from the correct account; supersedes #2010.

## Changes

### `authentication.md`

- **Version fix.** NGINX Node minimum for authentication flow detection corrected from `6.10.0` to `6.11.0`. Native Node `0.23.0` is unchanged.
- **New section: Customizing detected authentication parameters.** Documents the per-tenant `/v1/clients/<CLIENT_ID>/apid/config/auth-parameters` API:
  - `GET` to review the active list.
  - `POST` to register a new parameter, with the `point`-array shapes for header / cookie / query / form-encoded / JSON-body locations.
  - One-parameter-per-request constraint.
  - Per-cloud (`US` / `EU` / `ME`) curl examples in tabbed code blocks.
- **New subsection: Default detection parameters.** Lists the **34 default parameter names** that are detected automatically on all upgraded-node clients, grouped by location (header, cookie, query, form-encoded, JSON body), with a note on case-sensitivity.

### `track-changes.md`

- **New warning admonition** placed immediately after the **Unused** status bullet:
  > Endpoints with no qualifying requests for 35 days since their last update are automatically removed from the inventory and cannot be restored — re-discovery starts over and prior parameter / sensitive-data / authentication / risk-score history is not recovered.

## Why

- The `auth-parameters` API is already used by the security research team to extend tenant detection for non-standard schemes (OCP-APIM, Keycloak cookies, custom JWTs, …). Without docs, customers cannot self-serve.
- The 35-day retention surprises customers who expect their full history to remain available indefinitely.
- The `6.10.0` minimum was a misstatement; actual minimum is `6.11.0`.

## Validation

- Style checked against the `docs/latest/api-discovery/` conventions (American English, no contractions, second person, present tense, `<UPPERCASE_WITH_UNDERSCORES>` placeholders).
- Source for the 34-entry default list: cross-tenant traffic analysis (2026-04-23) applied via the internal `apply-auth-params.py` tooling to all upgraded-node tenants.
- Source for 35-day TTL: behavior of `api-discovery-server` against the `updated` timestamp.

Please double-check the table rendering in the **Default detection parameters** subsection on the Netlify preview.