### PR TITLE
API Discovery: fix retention to 30 days and document in data retention policy

### DIFF
--- a/docs/latest/about-wallarm/data-retention-policy.md
+++ b/docs/latest/about-wallarm/data-retention-policy.md
@@ -12,6 +12,21 @@ This policy outlines retention periods for different datasets collected by Walla
 | History of [allowlisted, denylisted, and graylisted IP addresses](../user-guides/ip-lists/overview.md)                                                                                                                                                                     | 3 months         | 3 months |
 | Automatically generated or manually created [rules](../user-guides/rules/rules.md) for proccessing traffic by Wallarm nodes                                                                                                              | ∞                | ∞ |
 | Wallarm account configuration: [users](../user-guides/settings/users.md), [applications](../user-guides/settings/applications.md), [integrations](../user-guides/settings/integrations/integrations-intro.md), [triggers](../user-guides/triggers/triggers.md) | ∞                | ∞ |
-| [Audit log](../user-guides/settings/audit-log.md) records                                                                                                                                                                           | 6 months         | 3 months         | 
+| [Audit log](../user-guides/settings/audit-log.md) records                                                                                                                                                                           | 6 months         | 3 months         |
+| [API Discovery](../api-discovery/overview.md) endpoint data | 30 days since last seen<sup>**</sup> | N/A |
 
 <small><sup>*</sup> Storing of security issues found by [AASM](../api-attack-surface/overview.md) can be limited by the AASM's [host retention policy](../api-attack-surface/setup.md#host-retention-policy).</small>
+
+<small><sup>**</sup> Different endpoint attributes are refreshed on their own schedule and are not all retained for the full 30 days. See [API Discovery data retention model](#api-discovery-data-retention-model) for details.</small>
+
+## API Discovery data retention model
+
+[API Discovery](../api-discovery/overview.md) builds a dynamic API inventory. Wallarm discovers the basic endpoint data (host, path, parameters, parameter types, application, discovered timestamp) within 5–7 minutes of the first matching request and preserves it for **30 days** since the last seen timestamp (the time of the most recent qualifying request). After 30 days without traffic, Wallarm automatically removes the endpoint together with all its associated data from the inventory. Removed entries cannot be restored — if traffic resumes later, the endpoint reappears as **New** and discovery starts over from scratch.
+
+Some endpoint attributes are recalculated on their own schedule and have no history tracking. If no traffic is received during the corresponding window, the attribute value is lost even while the endpoint itself remains in the inventory:
+
+| Attribute | Refresh schedule |
+| --- | --- |
+| Last seen timestamp | Updated instantly with every qualifying request |
+| Sensitive data, authentication flows, change status, requests counter | Recalculated continuously from the last 7 days of traffic — values are lost if no traffic is received for 7 days |
+| Risk score, business object, business flow | Recalculated every 4 hours from recent traffic, with no history tracking |

--- a/docs/latest/about-wallarm/data-retention-policy.md
+++ b/docs/latest/about-wallarm/data-retention-policy.md
@@ -13,20 +13,7 @@ This policy outlines retention periods for different datasets collected by Walla
 | Automatically generated or manually created [rules](../user-guides/rules/rules.md) for proccessing traffic by Wallarm nodes                                                                                                              | ∞                | ∞ |
 | Wallarm account configuration: [users](../user-guides/settings/users.md), [applications](../user-guides/settings/applications.md), [integrations](../user-guides/settings/integrations/integrations-intro.md), [triggers](../user-guides/triggers/triggers.md) | ∞                | ∞ |
 | [Audit log](../user-guides/settings/audit-log.md) records                                                                                                                                                                           | 6 months         | 3 months         |
-| [API Discovery](../api-discovery/overview.md) endpoint data | 30 days since last seen<sup>**</sup> | N/A |
+| [API Discovery](../api-discovery/overview.md) endpoint data (host, path, parameters, parameter types, application, discovered timestamp) | 30 days since last seen | 30 days since last seen |
+| [API Discovery](../api-discovery/overview.md) dynamic endpoint data (sensitive data, authentication flows, change status, requests counter) | 7 days since last seen | 7 days since last seen |
 
 <small><sup>*</sup> Storing of security issues found by [AASM](../api-attack-surface/overview.md) can be limited by the AASM's [host retention policy](../api-attack-surface/setup.md#host-retention-policy).</small>
-
-<small><sup>**</sup> Different endpoint attributes are refreshed on their own schedule and are not all retained for the full 30 days. See [API Discovery data retention model](#api-discovery-data-retention-model) for details.</small>
-
-## API Discovery data retention model
-
-[API Discovery](../api-discovery/overview.md) builds a dynamic API inventory. Wallarm discovers the basic endpoint data (host, path, parameters, parameter types, application, discovered timestamp) within 5–7 minutes of the first matching request and preserves it for **30 days** since the last seen timestamp (the time of the most recent qualifying request). After 30 days without traffic, Wallarm automatically removes the endpoint together with all its associated data from the inventory. Removed entries cannot be restored — if traffic resumes later, the endpoint reappears as **New** and discovery starts over from scratch.
-
-Some endpoint attributes are recalculated on their own schedule and have no history tracking. If no traffic is received during the corresponding window, the attribute value is lost even while the endpoint itself remains in the inventory:
-
-| Attribute | Refresh schedule |
-| --- | --- |
-| Last seen timestamp | Updated instantly with every qualifying request |
-| Sensitive data, authentication flows, change status, requests counter | Recalculated continuously from the last 7 days of traffic — values are lost if no traffic is received for 7 days |
-| Risk score, business object, business flow | Recalculated every 4 hours from recent traffic, with no history tracking |

--- a/docs/latest/about-wallarm/data-retention-policy.md
+++ b/docs/latest/about-wallarm/data-retention-policy.md
@@ -14,6 +14,6 @@ This policy outlines retention periods for different datasets collected by Walla
 | Wallarm account configuration: [users](../user-guides/settings/users.md), [applications](../user-guides/settings/applications.md), [integrations](../user-guides/settings/integrations/integrations-intro.md), [triggers](../user-guides/triggers/triggers.md) | ∞                | ∞ |
 | [Audit log](../user-guides/settings/audit-log.md) records                                                                                                                                                                           | 6 months         | 3 months         |
 | [API Discovery](../api-discovery/overview.md) endpoint data (host, path, parameters, parameter types, application, discovered timestamp) | 30 days since last seen | 30 days since last seen |
-| [API Discovery](../api-discovery/overview.md) dynamic endpoint data (sensitive data, authentication flows, change status, requests counter) | 7 days since last seen | 7 days since last seen |
+| [API Discovery](../api-discovery/overview.md) dynamic endpoint data (sensitive data, authentication flows, change status, requests counter) | 7 days | 7 days |
 
 <small><sup>*</sup> Storing of security issues found by [AASM](../api-attack-surface/overview.md) can be limited by the AASM's [host retention policy](../api-attack-surface/setup.md#host-retention-policy).</small>

--- a/docs/latest/api-discovery/track-changes.md
+++ b/docs/latest/api-discovery/track-changes.md
@@ -28,8 +28,8 @@ In the **Status** column for endpoints and parameters, API Discovery provides da
 
     * If later the endpoint in the `Unused` status is requested (with the code 200 in response) again it will lose the `Unused` status.
 
-!!! warning "Unused endpoints are removed after 35 days"
-    Endpoints that receive no qualifying requests for **35 days** since their last update are automatically removed from your API inventory, together with their parameters, sensitive-data history, authentication coverage, and risk-score evolution. **Removed entries cannot be restored.** If traffic to such an endpoint resumes later, the endpoint reappears as **New** and discovery starts over from scratch — past parameter information and history are not recovered.
+!!! warning "Unused endpoints are removed after 30 days"
+    Endpoints that receive no qualifying requests for **30 days** since their last update are automatically removed from your API inventory, together with their parameters, sensitive-data history, authentication coverage, and risk-score evolution. **Removed entries cannot be restored.** If traffic to such an endpoint resumes later, the endpoint reappears as **New** and discovery starts over from scratch — past parameter information and history are not recovered.
 
 ![API Discovery - track changes](../images/about-wallarm-waf/api-discovery-2.0/api-discovery-changes.png)
 


### PR DESCRIPTION
## Summary

- Fix the unused-endpoint removal period in [Tracking changes in API](https://docs.wallarm.com/api-discovery/track-changes/) from 35 to 30 days.
- Add two rows to the [Data retention policy](https://docs.wallarm.com/about-wallarm/data-retention-policy/) page for API Discovery: endpoint data (30 days since last seen) and dynamic endpoint data covering sensitive data, authentication flows, change status, and requests counter (7 days).

## Test plan

- [ ] Netlify preview: visit `/api-discovery/track-changes/` and confirm the warning admonition reads "Unused endpoints are removed after 30 days" with "30 days" in the body.
- [ ] Netlify preview: visit `/about-wallarm/data-retention-policy/` and confirm the table ends with two API Discovery rows showing 30 days / 30 days and 7 days / 7 days respectively.
- [ ] Confirm no leftover `35 day` references in the API Discovery section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)