### PR TITLE
docs: NGINX Node 6.12.5 release

### DIFF
--- a/docs/6.x/admin-en/installation-kubernetes-en.md
+++ b/docs/6.x/admin-en/installation-kubernetes-en.md
@@ -129,7 +129,7 @@ To install the Wallarm Ingress Controller:
 1. Install the Wallarm packages:
 
     ``` bash
-    helm install --version 6.12.4 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
+    helm install --version 6.12.5 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name for the Helm release of the Ingress controller chart

--- a/docs/6.x/updating-migrating/ingress-controller.md
+++ b/docs/6.x/updating-migrating/ingress-controller.md
@@ -44,7 +44,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.4 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.5 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>`: the name of the Helm release with the Ingress controller chart.
@@ -65,7 +65,7 @@ To install and run the plugin:
 Upgrade the deployed NGINX Ingress controller:
 
 ``` bash
-helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.4 -f <PATH_TO_VALUES>
+helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.5 -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>`: the name of the Helm release with the Ingress controller chart
@@ -84,7 +84,7 @@ helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.1
 
     Where `<NAMESPACE>` is the namespace the Helm chart with the Ingress controller is deployed to.
 
-    The chart version should correspond to `wallarm-ingress-6.12.4`.
+    The chart version should correspond to `wallarm-ingress-6.12.5`.
 1. Get the Wallarm pod:
     
     ``` bash

--- a/docs/6.x/updating-migrating/node-artifact-versions.md
+++ b/docs/6.x/updating-migrating/node-artifact-versions.md
@@ -19,6 +19,12 @@ new loggin variable wallarm_block_reason
 new attack types in logging variables and search bars?
 -->
 
+### 6.12.5 (2026-06-12)
+
+* Added support for Alpine and Debian packages
+* Added support for NGINX Plus R37
+* Fixed the [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975) NGINX vulnerability
+
 ### 6.12.4 (2026-06-04)
 
 * Added support for NGINX stable 1.30.2
@@ -277,6 +283,10 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 ## Helm chart for Wallarm NGINX Ingress controller
 
 [How to upgrade](ingress-controller.md)
+
+### 6.12.5 (2026-06-12)
+
+* Internal improvements
 
 ### 6.12.4 (2026-06-04)
 
@@ -547,6 +557,10 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 [How to upgrade](sidecar-proxy.md)
 
+### 6.12.5 (2026-06-12)
+
+* Fixed the [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975) NGINX vulnerability
+
 ### 6.12.4 (2026-06-04)
 
 * Changed the [Limit data export](../admin-en/export-to-cloud.md) rule — when applied, the node now preserves the request structure (parameter names and nesting) and masks only the values, instead of switching the matched traffic to metadata only
@@ -786,6 +800,10 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 ## NGINX-based Docker image
 
 [How to upgrade](docker-container.md)
+
+### 6.12.5 (2026-06-12)
+
+* Fixed the [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975) NGINX vulnerability
 
 ### 6.12.4 (2026-06-04)
 
@@ -1029,6 +1047,10 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 [How to upgrade](cloud-image.md)
 
+### 6.12.5 (2026-06-12)
+
+* Fixed the [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975) NGINX vulnerability
+
 ### 6.12.4 (2026-06-04)
 
 * Changed the [Limit data export](../admin-en/export-to-cloud.md) rule — when applied, the node now preserves the request structure (parameter names and nesting) and masks only the values, instead of switching the matched traffic to metadata only
@@ -1228,6 +1250,10 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 ## Google Cloud Platform Image
 
 [How to upgrade](cloud-image.md)
+
+### wallarm-node-6-12-5-20260610-102606 (2026-06-12)
+
+* Fixed the [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975) NGINX vulnerability
 
 ### wallarm-node-6-12-4-20260604-145803 (2026-06-04)
 

--- a/docs/6.x/updating-migrating/node-artifact-versions.md
+++ b/docs/6.x/updating-migrating/node-artifact-versions.md
@@ -21,9 +21,8 @@ new attack types in logging variables and search bars?
 
 ### 6.12.5 (2026-06-12)
 
-* Added support for Alpine and Debian packages
+* Added support for the latest Alpine and Debian/Ubuntu distribution NGINX package rebuilds shipping the upstream fix for [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975)
 * Added support for NGINX Plus R37
-* Fixed the [CVE-2026-49975](https://nvd.nist.gov/vuln/detail/CVE-2026-49975) NGINX vulnerability
 
 ### 6.12.4 (2026-06-04)
 

--- a/docs/latest/admin-en/chaining-wallarm-and-other-ingress-controllers.md
+++ b/docs/latest/admin-en/chaining-wallarm-and-other-ingress-controllers.md
@@ -121,7 +121,7 @@ To deploy the Wallarm Ingress controller and chain it with additional controller
     To learn more configuration options, please use the [link](configure-kubernetes-en.md).
 1. Install the Wallarm Ingress Helm chart:
     ``` bash
-    helm install --version 6.12.4 internal-ingress wallarm/wallarm-ingress -n wallarm-ingress -f values.yaml --create-namespace
+    helm install --version 6.12.5 internal-ingress wallarm/wallarm-ingress -n wallarm-ingress -f values.yaml --create-namespace
     ```
 
     * `internal-ingress` is the name of Helm release

--- a/docs/latest/admin-en/configure-wallarm-mode.md
+++ b/docs/latest/admin-en/configure-wallarm-mode.md
@@ -52,7 +52,7 @@ Note that described configuration is applicable only for [in-line](../installati
     When deploying the NGINX-based Wallarm nodes via docker containers, [pass](../admin-en/installation-docker-en.md#run-the-container-passing-the-environment-variables) the `WALLARM_MODE` environment variable:
 
     ```
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_MODE='monitoring' -p 80:80 wallarm/node:6.12.4
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_MODE='monitoring' -p 80:80 wallarm/node:6.12.5
     ```
 
     Alternatively, [include](../admin-en/installation-docker-en.md#run-the-container-mounting-the-configuration-file) the corresponding parameter in the configuration file and run the container mounting this file.

--- a/docs/latest/admin-en/installation-docker-en.md
+++ b/docs/latest/admin-en/installation-docker-en.md
@@ -26,15 +26,15 @@ To run the container:
 
     === "US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.12.5
         ```
     === "EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -p 80:80 wallarm/node:6.12.5
         ```
     === "ME Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='me1.api.wallarm.com' -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='me1.api.wallarm.com' -p 80:80 wallarm/node:6.12.5
         ```
 
 You can pass the following basic filtering node settings to the container via the option `-e`:
@@ -64,15 +64,15 @@ To run the container:
 
     === "US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.5
         ```
     === "EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.5
         ```
     === "ME Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.5
         ```
 
     * The `-e` option passes the following required environment variables to the container:

--- a/docs/latest/admin-en/installation-postanalytics-en.md
+++ b/docs/latest/admin-en/installation-postanalytics-en.md
@@ -31,11 +31,11 @@ To download all-in-one Wallarm installation script, execute the command:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.x86_64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.x86_64-glibc.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.aarch64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.aarch64-glibc.sh
     ```
 
 ## Step 2: Prepare Wallarm token
@@ -63,13 +63,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh postanalytics
     ```        
 
     The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -78,13 +78,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo sh wallarm-6.12.4.x86_64-glibc.sh postanalytics
+    sudo sh wallarm-6.12.5.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo sh wallarm-6.12.4.aarch64-glibc.sh postanalytics
+    sudo sh wallarm-6.12.5.aarch64-glibc.sh postanalytics
     ```
 
 ## Step 4: Configure the postanalytics module
@@ -168,13 +168,13 @@ Once the postanalytics module is installed on the separate server:
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -183,13 +183,13 @@ Once the postanalytics module is installed on the separate server:
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.x86_64-glibc.sh filtering
+        sudo sh wallarm-6.12.5.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.aarch64-glibc.sh filtering
+        sudo sh wallarm-6.12.5.aarch64-glibc.sh filtering
         ```
 
 ## Step 8: Connect the NGINX-Wallarm module to the postanalytics module

--- a/docs/latest/installation/cloud-platforms/alibaba-cloud/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/alibaba-cloud/docker-container.md
@@ -44,15 +44,15 @@ To deploy the containerized Wallarm filtering node configured only through envir
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.12.5
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -p 80:80 wallarm/node:6.12.5
         ```
     === "Command for the Wallarm ME Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='me1.api.wallarm.com' -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='me1.api.wallarm.com' -p 80:80 wallarm/node:6.12.5
         ```
         
     * `-p`: port the filtering node listens to. The value should be the same as the instance port.
@@ -112,15 +112,15 @@ To deploy the containerized Wallarm filtering node configured through environmen
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.5
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.5
         ```
     === "Command for the Wallarm ME Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.5
         ```
 
     * `<INSTANCE_PATH_TO_CONFIG>`: path to the configuration file created in the previous step. For example, `configs`.

--- a/docs/latest/installation/cloud-platforms/aws/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/aws/docker-container.md
@@ -123,7 +123,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.4"
+                "image": "registry-1.docker.io/wallarm/node:6.12.5"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -161,7 +161,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.4"
+                "image": "registry-1.docker.io/wallarm/node:6.12.5"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -203,7 +203,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.4"
+                "image": "registry-1.docker.io/wallarm/node:6.12.5"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -338,7 +338,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.4"
+                "image": "registry-1.docker.io/wallarm/node:6.12.5"
                 }
             ],
             "volumes": [
@@ -387,7 +387,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.4"
+                "image": "registry-1.docker.io/wallarm/node:6.12.5"
                 }
             ],
             "volumes": [
@@ -440,7 +440,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.4"
+                "image": "registry-1.docker.io/wallarm/node:6.12.5"
                 }
             ],
             "volumes": [
@@ -537,7 +537,7 @@ To avoid this, authenticate ECS tasks to Docker Hub using a paid Docker Hub acco
     "containerDefinitions": [
         {
             "name": "wallarm-container",
-            "image": "registry-1.docker.io/wallarm/node:6.12.4",
+            "image": "registry-1.docker.io/wallarm/node:6.12.5",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:<DOCKER_HUB_SECRET_NAME>"
             },

--- a/docs/latest/installation/cloud-platforms/azure/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/azure/docker-container.md
@@ -60,7 +60,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.4 \
+            --image registry-1.docker.io/wallarm/node:6.12.5 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_API_HOST='us1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
          ```
     === "Command for the Wallarm EU Cloud"
@@ -70,7 +70,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.4 \
+            --image registry-1.docker.io/wallarm/node:6.12.5 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_LABELS='group=<GROUP>'
          ```
     === "Command for the Wallarm ME Cloud"
@@ -80,7 +80,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.4 \
+            --image registry-1.docker.io/wallarm/node:6.12.5 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_API_HOST='me1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
          ```
 
@@ -158,7 +158,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.4 \
+            --image registry-1.docker.io/wallarm/node:6.12.5 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_API_HOST='us1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
@@ -170,7 +170,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.4 \
+            --image registry-1.docker.io/wallarm/node:6.12.5 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_LABELS='group=<GROUP>'
@@ -182,7 +182,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.4 \
+            --image registry-1.docker.io/wallarm/node:6.12.5 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_API_HOST='me1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'

--- a/docs/latest/installation/cloud-platforms/gcp/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/gcp/docker-container.md
@@ -45,7 +45,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
             --container-env WALLARM_API_HOST=us1.api.wallarm.com \
-            --container-image registry-1.docker.io/wallarm/node:6.12.4
+            --container-image registry-1.docker.io/wallarm/node:6.12.5
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
@@ -54,7 +54,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --tags http-server \
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
-            --container-image registry-1.docker.io/wallarm/node:6.12.4
+            --container-image registry-1.docker.io/wallarm/node:6.12.5
         ```
     === "Command for the Wallarm ME Cloud"
         ```bash
@@ -64,7 +64,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
             --container-env WALLARM_API_HOST=me1.api.wallarm.com \
-            --container-image registry-1.docker.io/wallarm/node:6.12.4
+            --container-image registry-1.docker.io/wallarm/node:6.12.5
         ```
 
     * `<INSTANCE_NAME>`: name of the instance, for example: `wallarm-node`.
@@ -139,15 +139,15 @@ To deploy the containerized Wallarm filtering node configured through environmen
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.5
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.5
         ```
     === "Command for the Wallarm ME Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.4
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.5
         ```
 
     * `<INSTANCE_PATH_TO_CONFIG>`: path to the configuration file created in the previous step. For example, `configs`.

--- a/docs/latest/installation/heroku/docker-image.md
+++ b/docs/latest/installation/heroku/docker-image.md
@@ -339,7 +339,7 @@ To deploy Wallarm's Docker image on Heroku, start by creating the necessary conf
     ```dockerfile
     FROM ubuntu:22.04
 
-    ARG VERSION="6.12.4"
+    ARG VERSION="6.12.5"
 
     ENV PORT=3000
     ENV WALLARM_LABELS="group=heroku"
@@ -396,10 +396,10 @@ To deploy Wallarm's Docker image on Heroku, start by creating the necessary conf
 Execute the following commands within the previously created directory:
 
 ```
-docker build -t wallarm-heroku:6.12.4 .
+docker build -t wallarm-heroku:6.12.5 .
 docker login
-docker tag wallarm-heroku:6.12.4 <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.4
-docker push <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.4
+docker tag wallarm-heroku:6.12.5 <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.5
+docker push <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.5
 ```
 
 ## Step 3: Run the built Docker image on Heroku
@@ -410,7 +410,7 @@ To deploy the image on Heroku:
 1. Construct a `Dockerfile` which will include the installation of necessary dependencies specific to your app's runtime. For a Node.js application, use the following template:
 
     ```dockerfile
-    FROM <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.4
+    FROM <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.5
 
     ENV NODE_MAJOR=20
 

--- a/docs/latest/installation/kubernetes/sidecar-proxy/deployment.md
+++ b/docs/latest/installation/kubernetes/sidecar-proxy/deployment.md
@@ -113,7 +113,7 @@ Generate a filtering node token of the [appropriate type][node-token-types] to c
 1. Deploy the Wallarm Helm chart:
 
     ``` bash
-    helm install --version 6.12.4 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar --create-namespace -f <PATH_TO_VALUES>
+    helm install --version 6.12.5 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar --create-namespace -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name for the Helm release of the Wallarm Sidecar chart

--- a/docs/latest/updating-migrating/docker-container.md
+++ b/docs/latest/updating-migrating/docker-container.md
@@ -31,7 +31,7 @@ To upgrade the end‑of‑life node (3.6 or lower), please use the [different in
 ## Step 1: Download the updated filtering node image
 
 ``` bash
-docker pull wallarm/node:6.12.4
+docker pull wallarm/node:6.12.5
 ```
 
 ## Step 2: Stop the running container

--- a/docs/latest/updating-migrating/nginx-modules.md
+++ b/docs/latest/updating-migrating/nginx-modules.md
@@ -92,13 +92,13 @@ To upgrade the end‑of‑life node (3.6 or lower), please use the [different in
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -107,13 +107,13 @@ To upgrade the end‑of‑life node (3.6 or lower), please use the [different in
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.x86_64-glibc.sh filtering
+        sudo sh wallarm-6.12.5.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.aarch64-glibc.sh filtering
+        sudo sh wallarm-6.12.5.aarch64-glibc.sh filtering
         ```
 
 ## Step 6: Transfer NGINX and postanalytics configuration from old node machine to new

--- a/docs/latest/updating-migrating/older-versions/docker-container.md
+++ b/docs/latest/updating-migrating/older-versions/docker-container.md
@@ -41,7 +41,7 @@ The module operation can cause [false positives](../../about-wallarm/protecting-
 ## Step 4: Download the updated filtering node image
 
 ``` bash
-docker pull wallarm/node:6.12.4
+docker pull wallarm/node:6.12.5
 ```
 
 ## Step 5: Switch to the token-based connection to the Wallarm Cloud

--- a/docs/latest/updating-migrating/older-versions/ingress-controller.md
+++ b/docs/latest/updating-migrating/older-versions/ingress-controller.md
@@ -209,7 +209,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.4 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.5 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>`: the name of the Helm release with the Ingress controller chart
@@ -316,7 +316,7 @@ By using this method, you can deploy Ingress Controller 6.x as an additional ent
 2. Deploy the Ingress controller 6.x:
 
     ```bash
-    helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.4 -f <PATH_TO_VALUES>
+    helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.5 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>`: the name for the Helm release of the Ingress controller chart
@@ -352,7 +352,7 @@ To re‑create the Ingress controller release:
     2. Create a new release with Ingress controller 6.x:
 
         ```bash
-        helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.4 -f <PATH_TO_VALUES>
+        helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.5 -f <PATH_TO_VALUES>
         ```
 
         * `<RELEASE_NAME>`: the name for the Helm release of the Ingress controller chart
@@ -404,7 +404,7 @@ Release re‑creation will take several minutes and the Ingress controller will 
 
     ```bash
     cat objects-to-remove.txt | xargs kubectl delete --wait=false -n <NAMESPACE>    && \
-    helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.4 -f `<PATH_TO_VALUES>`
+    helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.5 -f `<PATH_TO_VALUES>`
     ```
 
     To decrease service downtime, it is NOT recommended to execute commands separately.
@@ -430,7 +430,7 @@ There are the following parameters passed in the commands:
     helm ls
     ```
 
-    The chart version should correspond to `wallarm-ingress-6.12.4`.
+    The chart version should correspond to `wallarm-ingress-6.12.5`.
 1. Get the Wallarm pod:
     
     ``` bash

--- a/docs/latest/updating-migrating/older-versions/nginx-modules.md
+++ b/docs/latest/updating-migrating/older-versions/nginx-modules.md
@@ -106,13 +106,13 @@ The module operation can cause [false positives](../../about-wallarm/protecting-
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -121,13 +121,13 @@ The module operation can cause [false positives](../../about-wallarm/protecting-
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.x86_64-glibc.sh filtering
+        sudo sh wallarm-6.12.5.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
         
         ```bash
-        sudo sh wallarm-6.12.4.aarch64-glibc.sh filtering
+        sudo sh wallarm-6.12.5.aarch64-glibc.sh filtering
         ```
 
 ## Step 7: Migrate allowlists and denylists from the previous Wallarm node version to 6.x (only if upgrading node 2.18 or lower)

--- a/docs/latest/updating-migrating/older-versions/what-is-new.md
+++ b/docs/latest/updating-migrating/older-versions/what-is-new.md
@@ -642,7 +642,7 @@ Now you can easily group node instances using one [**API token**](../../user-gui
 For example: 
 
 ```bash
-docker run -d -e WALLARM_API_TOKEN='<API TOKEN WITH DEPLOY ROLE>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_LABELS='group=<GROUP>' -p 80:80 wallarm/node:6.12.4
+docker run -d -e WALLARM_API_TOKEN='<API TOKEN WITH DEPLOY ROLE>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_LABELS='group=<GROUP>' -p 80:80 wallarm/node:6.12.5
 ```
 ...will place node instance into the `<GROUP>` instance group (existing, or, if does not exist, it will be created).
 

--- a/docs/latest/updating-migrating/sidecar-proxy.md
+++ b/docs/latest/updating-migrating/sidecar-proxy.md
@@ -29,7 +29,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n wallarm-sidecar wallarm/wallarm-sidecar --version 6.12.4 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n wallarm-sidecar wallarm/wallarm-sidecar --version 6.12.5 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name of the Wallarm Sidecar Helm release.
@@ -64,7 +64,7 @@ kubectl delete secret <RELEASE_NAME>-wallarm-sidecar-admission-tls -n wallarm-si
 ### Step 5: Deploy the new solution version
 
 ``` bash
-helm install --version 6.12.4 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar -f <PATH_TO_VALUES>
+helm install --version 6.12.5 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>` is the name for the Helm release. It is recommended to re-use the same name you used for the initial deployment of the solution.
@@ -91,7 +91,7 @@ kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
 Upgrade the deployed components of the Sidecar solution:
 
 ``` bash
-helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-sidecar --version 6.12.4 -f <PATH_TO_VALUES>
+helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-sidecar --version 6.12.5 -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>`: the name of the Helm release with the deployed Sidecar chart
@@ -121,7 +121,7 @@ kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
 
     Where `wallarm-sidecar` is the namespace the Sidecar is deployed to. You can change this value if the namespace is different.
 
-    The chart version should correspond to `wallarm-sidecar-6.12.4`.
+    The chart version should correspond to `wallarm-sidecar-6.12.5`.
 1. Get the Wallarm control plane details to check it has been successfully started:
 
     ```bash

--- a/docs/latest/updating-migrating/what-is-new.md
+++ b/docs/latest/updating-migrating/what-is-new.md
@@ -266,11 +266,11 @@ The image configuration has moved from `controller.image` and `controller.wallar
       image:
         registry: <YOUR_REGISTRY>
         image: wallarm/ingress-controller
-        tag: "6.12.4"
+        tag: "6.12.5"
       wallarm:
         helpers:
           image: <YOUR_REGISTRY>/wallarm/node-helpers
-          tag: "6.12.4"
+          tag: "6.12.5"
     ```
 === "F5-based (7.x)"
     ```yaml

--- a/docs/latest/user-guides/rules/rules.md
+++ b/docs/latest/user-guides/rules/rules.md
@@ -301,12 +301,12 @@ To test a regular expression, use the Wallarm **cpire** utility. Install it via 
     1. Download the Wallarm all-in-one installer if it is not downloaded yet:
 
         ```
-        curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.x86_64-glibc.sh
+        curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.x86_64-glibc.sh
         ```
     1. Install the Wallarm modules if they are not installed yet:
         
         ```
-        sudo sh wallarm-6.12.4.x86_64-glibc.sh -- --batch --token <API_TOKEN>
+        sudo sh wallarm-6.12.5.x86_64-glibc.sh -- --batch --token <API_TOKEN>
         ```
     1. Run the **cpire** utility:
         
@@ -318,7 +318,7 @@ To test a regular expression, use the Wallarm **cpire** utility. Install it via 
     1. Run the **cpire** utility from the Wallarm Docker image:
     
         ```
-        docker run --rm -it wallarm/node:6.12.4 /opt/wallarm/usr/bin/cpire-runner -r '<YOUR_REGULAR_EXPRESSION>'
+        docker run --rm -it wallarm/node:6.12.5 /opt/wallarm/usr/bin/cpire-runner -r '<YOUR_REGULAR_EXPRESSION>'
         ```
     1. Enter the value to check whether it matches with the regular expression.
 

--- a/include/waf/installation/all-in-one-installer-download.md
+++ b/include/waf/installation/all-in-one-installer-download.md
@@ -7,9 +7,9 @@ To download all-in-one Wallarm installation script, execute the command:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.x86_64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.x86_64-glibc.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.aarch64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.aarch64-glibc.sh
     ```

--- a/include/waf/installation/all-in-one-installer-run.md
+++ b/include/waf/installation/all-in-one-installer-run.md
@@ -4,13 +4,13 @@
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh
         ```        
 
         The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -19,13 +19,13 @@
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.x86_64-glibc.sh
+        sudo sh wallarm-6.12.5.x86_64-glibc.sh
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-6.12.4.aarch64-glibc.sh
+        sudo sh wallarm-6.12.5.aarch64-glibc.sh
         ```
 
 1. Select [US Cloud](https://us1.my.wallarm.com/) or [EU Cloud](https://my.wallarm.com/), or [ME Cloud](https://me1.my.wallarm.com/).
@@ -37,11 +37,11 @@
     The command for x86_64:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh -- --batch -t <TOKEN> -H me1.api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh -- --batch -t <TOKEN> -H me1.api.wallarm.com
     ```
 
     The command for ARM64:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh -- --batch -t <TOKEN> -H me1.api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh -- --batch -t <TOKEN> -H me1.api.wallarm.com
     ```

--- a/include/waf/installation/all-in-one-nginx-latest.md
+++ b/include/waf/installation/all-in-one-nginx-latest.md
@@ -2,7 +2,7 @@ Install the latest NGINX version of:
 
 * **NGINX `stable`** (the latest supported version is v1.30.2) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
 * **NGINX Mainline** (the latest supported version is v1.31.1) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
-* **NGINX Plus** (the latest supported version is NGINX Plus R35) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
+* **NGINX Plus** (the latest supported version is NGINX Plus R37) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
 * **Distribution-Provided NGINX** - to install, use the following commands:
 
     === "Debian"

--- a/include/waf/installation/all-in-one-postanalytics.md
+++ b/include/waf/installation/all-in-one-postanalytics.md
@@ -4,13 +4,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh postanalytics
     ```        
 
     The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -19,11 +19,11 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo sh wallarm-6.12.4.x86_64-glibc.sh postanalytics
+    sudo sh wallarm-6.12.5.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo sh wallarm-6.12.4.aarch64-glibc.sh postanalytics
+    sudo sh wallarm-6.12.5.aarch64-glibc.sh postanalytics
     ```

--- a/include/waf/installation/all-in-one/launch-options.md
+++ b/include/waf/installation/all-in-one/launch-options.md
@@ -1,7 +1,7 @@
 As soon as you have the all-in one script downloaded, you can get help on it with:
 
 ```
-sudo sh ./wallarm-6.12.4.x86_64-glibc.sh -- -h
+sudo sh ./wallarm-6.12.5.x86_64-glibc.sh -- -h
 ```
 
 Which returns:
@@ -48,37 +48,37 @@ Below are examples of commands to run the script in batch mode for node installa
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh -- --batch -t <TOKEN> -c US
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh -- --batch -t <TOKEN> -c US
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh -- --batch -t <TOKEN> -c US
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh -- --batch -t <TOKEN> -c US
     ```
 === "EU Cloud"
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh -- --batch -t <TOKEN>
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh -- --batch -t <TOKEN>
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh -- --batch -t <TOKEN>
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh -- --batch -t <TOKEN>
     ```
 === "ME Cloud"
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.x86_64-glibc.sh -- --batch -t <TOKEN> -c ME
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.x86_64-glibc.sh -- --batch -t <TOKEN> -c ME
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.4.aarch64-glibc.sh -- --batch -t <TOKEN> -c ME
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.5.aarch64-glibc.sh -- --batch -t <TOKEN> -c ME
     ```
 
 ### Separate execution of node installation stages
@@ -94,48 +94,48 @@ This functionality is supported starting from version 4.10.0 of the all-in-one i
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.x86_64-glibc.sh
-    sudo sh wallarm-6.12.4.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.x86_64-glibc.sh
+    sudo sh wallarm-6.12.5.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c US
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.aarch64-glibc.sh
-    sudo sh wallarm-6.12.4.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.aarch64-glibc.sh
+    sudo sh wallarm-6.12.5.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c US
     ```
 === "EU Cloud"
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.x86_64-glibc.sh
-    sudo sh wallarm-6.12.4.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.x86_64-glibc.sh
+    sudo sh wallarm-6.12.5.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN>
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.aarch64-glibc.sh
-    sudo sh wallarm-6.12.4.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.aarch64-glibc.sh
+    sudo sh wallarm-6.12.5.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN>
     ```
 === "ME Cloud"
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.x86_64-glibc.sh
-    sudo sh wallarm-6.12.4.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.x86_64-glibc.sh
+    sudo sh wallarm-6.12.5.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c ME
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.4.aarch64-glibc.sh
-    sudo sh wallarm-6.12.4.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.5.aarch64-glibc.sh
+    sudo sh wallarm-6.12.5.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c ME
     ```
 Finally, to complete the installation, you need to [enable Wallarm to analyze traffic][enable-traffic-analysis-step] and [restart NGINX][restart-nginx-step].

--- a/include/waf/installation/cloud-platforms/reqs-and-steps-to-deploy-gcp-image.md
+++ b/include/waf/installation/cloud-platforms/reqs-and-steps-to-deploy-gcp-image.md
@@ -29,7 +29,7 @@ When using a tool like Terraform to launch the filtering node instance using Wal
 * To launch the instance with the filtering node version 6.x, please use the following image name:
 
     ```bash
-    wallarm-node-195710/wallarm-node-6-12-4-20260604-145803
+    wallarm-node-195710/wallarm-node-6-12-5-20260610-102606
     ```
 
 To get the image name, you can also follow these steps:
@@ -43,7 +43,7 @@ To get the image name, you can also follow these steps:
 3. Copy the version value from the name of the latest available image and paste the copied value into the provided image name format. For example, the filtering node version 6.x image will have the following name:
 
     ```bash
-    wallarm-node-195710/wallarm-node-6-12-4-20260604-145803
+    wallarm-node-195710/wallarm-node-6-12-5-20260610-102606
     ```
 
 ## 2. Configure the filtering node instance


### PR DESCRIPTION
Add 6.12.5 changelog entries (AIO, NGINX Ingress Helm, Sidecar Helm, Docker image, AMI, GCP image): Alpine and Debian packages, NGINX Plus R37, and the CVE-2026-49975 NGINX fix. Bump NGINX Plus latest-supported note R35 -> R37, bump 6.12.4 -> 6.12.5 across install docs and includes, and set the GCP image name to wallarm-node-6-12-5-20260610-102606.