### PR TITLE
Document Native Node 0.25.3 release

### DIFF
--- a/docs/latest/installation/native-node/all-in-one.md
+++ b/docs/latest/installation/native-node/all-in-one.md
@@ -60,13 +60,13 @@ Download Wallarm installation script and make it executable:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/native/aio-native-0.25.2.x86_64.sh
-    chmod +x aio-native-0.25.2.x86_64.sh
+    curl -O https://meganode.wallarm.com/native/aio-native-0.25.3.x86_64.sh
+    chmod +x aio-native-0.25.3.x86_64.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/native/aio-native-0.25.2.aarch64.sh
-    chmod +x aio-native-0.25.2.aarch64.sh
+    curl -O https://meganode.wallarm.com/native/aio-native-0.25.3.aarch64.sh
+    chmod +x aio-native-0.25.3.aarch64.sh
     ```
 
 ### 3. Prepare the configuration file
@@ -121,19 +121,19 @@ Create the `wallarm-node-conf.yaml` file on the machine with the following minim
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
         ```
 
     For the ARM64 installer version:
@@ -141,19 +141,19 @@ Create the `wallarm-node-conf.yaml` file on the machine with the following minim
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
         ```
 === "tcp-capture-v2"
     For the x86_64 installer version:
@@ -161,19 +161,19 @@ Create the `wallarm-node-conf.yaml` file on the machine with the following minim
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
         ```
 
     For the ARM64 installer version:
@@ -181,19 +181,19 @@ Create the `wallarm-node-conf.yaml` file on the machine with the following minim
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
         ```
 === "envoy-external-filter"
     For the x86_64 installer version:
@@ -201,19 +201,19 @@ Create the `wallarm-node-conf.yaml` file on the machine with the following minim
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
         ```
 
     For the ARM64 installer version:
@@ -221,19 +221,19 @@ Create the `wallarm-node-conf.yaml` file on the machine with the following minim
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
         ```
 
 Parameter values:
@@ -290,21 +290,21 @@ You can also verify the Node operation by checking its [Prometheus metrics](../.
 
     === "x86_64 version"
         ```
-        sudo ./aio-native-0.25.2.x86_64.sh -- --help
+        sudo ./aio-native-0.25.3.x86_64.sh -- --help
         ```
     === "ARM64 version"
         ```
-        sudo ./aio-native-0.25.2.aarch64.sh -- --help
+        sudo ./aio-native-0.25.3.aarch64.sh -- --help
         ```
 * You can also run the installer in an **interactive** mode and choose the required mode in the 1st step:
 
     === "x86_64 version"
         ```
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh
         ```
     === "ARM64 version"
         ```
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh
         ```
 
 * <a name="apid-only-mode"></a>You can use the node in API Discovery-only mode (available since version 0.12.1). In this mode, attacks - including those detected by the Node's built-in mechanisms and those requiring additional configuration (e.g., credential stuffing, API specification violation attempts, and malicious activity from denylisted and graylisted IPs) - are detected and blocked locally (if enabled) but not exported to Wallarm Cloud. Since there is no attack data in the Cloud, [Threat Replay Testing](../../vulnerability-detection/threat-replay-testing/overview.md) does not work. Traffic from whitelisted IPs is allowed.

--- a/docs/latest/installation/native-node/docker-image.md
+++ b/docs/latest/installation/native-node/docker-image.md
@@ -51,7 +51,7 @@ The Docker image for the Native Node is ideal if you are already using container
 ### 1. Pull the Docker image
 
 ```
-docker pull wallarm/node-native-aio:0.25.2
+docker pull wallarm/node-native-aio:0.25.3
 ```
 
 ### 2. Prepare the configuration file
@@ -95,15 +95,15 @@ To run the Docker image, use the following commands. Mount the `wallarm-node-con
 
 === "US Cloud"
     ```bash
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.2
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.3
     ```
 === "EU Cloud"
     ```bash
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.2
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.3
     ```
 === "ME Cloud"
     ```bash
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.2
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.3
     ```
 
 Environment variable | Description| Required

--- a/docs/latest/installation/native-node/helm-chart.md
+++ b/docs/latest/installation/native-node/helm-chart.md
@@ -299,15 +299,15 @@ helm repo update wallarm
 
 === "US Cloud"
     ```
-    helm upgrade --install --version 0.25.2 <WALLARM_RELEASE_NAME> wallarm/wallarm-node-native -n wallarm-node --create-namespace -f <PATH_TO_VALUES> --set config.api.token=<WALLARM_API_TOKEN> --set config.api.host=us1.api.wallarm.com
+    helm upgrade --install --version 0.25.3 <WALLARM_RELEASE_NAME> wallarm/wallarm-node-native -n wallarm-node --create-namespace -f <PATH_TO_VALUES> --set config.api.token=<WALLARM_API_TOKEN> --set config.api.host=us1.api.wallarm.com
     ```
 === "EU Cloud"
     ```
-    helm upgrade --install --version 0.25.2 <WALLARM_RELEASE_NAME> wallarm/wallarm-node-native -n wallarm-node --create-namespace -f <PATH_TO_VALUES> --set config.api.token=<WALLARM_API_TOKEN> --set config.api.host=api.wallarm.com
+    helm upgrade --install --version 0.25.3 <WALLARM_RELEASE_NAME> wallarm/wallarm-node-native -n wallarm-node --create-namespace -f <PATH_TO_VALUES> --set config.api.token=<WALLARM_API_TOKEN> --set config.api.host=api.wallarm.com
     ```
 === "ME Cloud"
     ```
-    helm upgrade --install --version 0.25.2 <WALLARM_RELEASE_NAME> wallarm/wallarm-node-native -n wallarm-node --create-namespace -f <PATH_TO_VALUES> --set config.api.token=<WALLARM_API_TOKEN> --set config.api.host=me1.api.wallarm.com
+    helm upgrade --install --version 0.25.3 <WALLARM_RELEASE_NAME> wallarm/wallarm-node-native -n wallarm-node --create-namespace -f <PATH_TO_VALUES> --set config.api.token=<WALLARM_API_TOKEN> --set config.api.host=me1.api.wallarm.com
     ```
 
 ### 5. Configure DNS access to the Wallarm Node

--- a/docs/latest/installation/oob/tcp-traffic-mirror/deployment.md
+++ b/docs/latest/installation/oob/tcp-traffic-mirror/deployment.md
@@ -61,13 +61,13 @@ To download Wallarm installation script and make it executable, use the followin
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/native/aio-native-0.25.2.x86_64.sh
-    chmod +x aio-native-0.25.2.x86_64.sh
+    curl -O https://meganode.wallarm.com/native/aio-native-0.25.3.x86_64.sh
+    chmod +x aio-native-0.25.3.x86_64.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/native/aio-native-0.25.2.aarch64.sh
-    chmod +x aio-native-0.25.2.aarch64.sh
+    curl -O https://meganode.wallarm.com/native/aio-native-0.25.3.aarch64.sh
+    chmod +x aio-native-0.25.3.aarch64.sh
     ```
 
 ## Step 3: Prepare the configuration file
@@ -248,37 +248,37 @@ To install the Wallarm node for TCP traffic mirror analysis, run the following c
     US Cloud:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
     ```
 
     EU Cloud:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
     ```
 
     ME Cloud:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
     ```
 === "ARM64 version"
     US Cloud:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com
     ```
 
     EU Cloud:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com
     ```
 
     ME Cloud:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
+    sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com
     ```
 
 * The `WALLARM_LABELS` variable sets group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -323,21 +323,21 @@ For additional debugging, set the [`log.level`](../../native-node/all-in-one-con
 
     === "x86_64 version"
         ```
-        sudo ./aio-native-0.25.2.x86_64.sh -- --help
+        sudo ./aio-native-0.25.3.x86_64.sh -- --help
         ```
     === "ARM64 version"
         ```
-        sudo ./aio-native-0.25.2.aarch64.sh -- --help
+        sudo ./aio-native-0.25.3.aarch64.sh -- --help
         ```
 * You can also run the installer in an **interactive** mode and choose the `tcp-capture-v2` mode in the 1st step:
 
     === "x86_64 version"
         ```
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh
         ```
     === "ARM64 version"
         ```
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh
         ```
 * You can use the node in API Discovery-only mode (available since version 0.12.1). In this mode, attacks - including those detected by the Node's built-in mechanisms and those requiring additional configuration (e.g., credential stuffing, API specification violation attempts and brute force) - are detected and [logged](../../../admin-en/configure-logging.md) locally but not exported to Wallarm Cloud. Since there is no attack data in the Cloud, [Threat Replay Testing](../../../vulnerability-detection/threat-replay-testing/overview.md) does not work.
 

--- a/docs/latest/updating-migrating/native-node/all-in-one.md
+++ b/docs/latest/updating-migrating/native-node/all-in-one.md
@@ -29,13 +29,13 @@ Download the latest installer version on the machine where your current Native N
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/native/aio-native-0.25.2.x86_64.sh
-    chmod +x aio-native-0.25.2.x86_64.sh
+    curl -O https://meganode.wallarm.com/native/aio-native-0.25.3.x86_64.sh
+    chmod +x aio-native-0.25.3.x86_64.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/native/aio-native-0.25.2.aarch64.sh
-    chmod +x aio-native-0.25.2.aarch64.sh
+    curl -O https://meganode.wallarm.com/native/aio-native-0.25.3.aarch64.sh
+    chmod +x aio-native-0.25.3.aarch64.sh
     ```
 
 ## 2. Run the new installer
@@ -69,19 +69,19 @@ For the configuration file, you can reuse the one used during the initial instal
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
         ```
 
     For the ARM64 installer version:
@@ -89,19 +89,19 @@ For the configuration file, you can reuse the one used during the initial instal
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=connector-server --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
         ```
 === "tcp-capture-v2"
     The `tcp-capture-v2` mode is used when you deployed the self-hosted node for [TCP traffic analysis](../../installation/oob/tcp-traffic-mirror/deployment.md).
@@ -127,19 +127,19 @@ For the configuration file, you can reuse the one used during the initial instal
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
         ```
 
     The upgrade command for the ARM64 installer version:
@@ -147,19 +147,19 @@ For the configuration file, you can reuse the one used during the initial instal
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=tcp-capture-v2 --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
         ```
 === "envoy-external-filter"
     The `envoy-external-filter` mode is used for [gRPC-based external processing filter](../../installation/connectors/istio.md) for APIs managed by Istio.
@@ -169,19 +169,19 @@ For the configuration file, you can reuse the one used during the initial instal
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.x86_64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
         ```
 
     The upgrade command for the ARM64 installer version:
@@ -189,19 +189,19 @@ For the configuration file, you can reuse the one used during the initial instal
     * US Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host us1.api.wallarm.com --preserve false
         ```
 
     * EU Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host api.wallarm.com --preserve false
         ```
 
     * ME Cloud:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.2.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
+        sudo env WALLARM_LABELS='group=<GROUP>' ./aio-native-0.25.3.aarch64.sh -- --batch --token <API_TOKEN> --mode=envoy-external-filter --go-node-config=<PATH_TO_CONFIG> --host me1.api.wallarm.com --preserve false
         ```
 
 Parameter values:

--- a/docs/latest/updating-migrating/native-node/docker-image.md
+++ b/docs/latest/updating-migrating/native-node/docker-image.md
@@ -25,7 +25,7 @@ These instructions describe the steps to upgrade the [Native Node deployed from 
 ## 1. Download the new Docker image version
 
 ```
-docker pull wallarm/node-native-aio:0.25.2
+docker pull wallarm/node-native-aio:0.25.3
 ```
 
 ## 2. Stop the running container
@@ -53,15 +53,15 @@ docker stop <RUNNING_CONTAINER_NAME>
 
 === "US Cloud"
     ```bash
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.2
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.3
     ```
 === "EU Cloud"
     ```bash
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.2
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.3
     ```
 === "ME Cloud"
     ```bash
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.2
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='me1.api.wallarm.com' -v ./wallarm-node-conf.yaml:/opt/wallarm/etc/wallarm/go-node.yaml -p 80:5050 wallarm/node-native-aio:0.25.3
     ```
 
 Environment variable | Description| Required

--- a/docs/latest/updating-migrating/native-node/helm-chart.md
+++ b/docs/latest/updating-migrating/native-node/helm-chart.md
@@ -36,7 +36,7 @@ helm repo update wallarm
 Upgrade the deployed Kubernetes service or Load Balancer:
 
 ``` bash
-helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-node-native --version 0.25.2 -f <PATH_TO_VALUES>
+helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-node-native --version 0.25.3 -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>`: the name of the existing Helm release

--- a/docs/latest/updating-migrating/native-node/node-artifact-versions.md
+++ b/docs/latest/updating-migrating/native-node/node-artifact-versions.md
@@ -13,6 +13,7 @@ History of all-in-one installer updates simultaneously applies to it's x86_64 an
 ### 0.25.3 (2026-06-22)
 
 * Improved [MCP (Model Context Protocol)](../../api-discovery/exploring.md#mcp-servers) traffic analysis logging — the Node no longer produces excessive log output when there is no MCP traffic
+* Changed the [Limit data export](../admin-en/export-to-cloud.md) rule — when applied, the node now preserves the request structure (parameter names and nesting) and masks only the values, instead of switching the matched traffic to metadata only
 
 ### 0.25.2 (2026-06-05)
 
@@ -288,6 +289,7 @@ The Helm chart for the Native Node is used for self-hosted node deployments with
 ### 0.25.3 (2026-06-22)
 
 * Improved [MCP (Model Context Protocol)](../../api-discovery/exploring.md#mcp-servers) traffic analysis logging — the Node no longer produces excessive log output when there is no MCP traffic
+* Changed the [Limit data export](../admin-en/export-to-cloud.md) rule — when applied, the node now preserves the request structure (parameter names and nesting) and masks only the values, instead of switching the matched traffic to metadata only
 * Fixed security vulnerabilities: [CVE-2026-34182](https://nvd.nist.gov/vuln/detail/CVE-2026-34182), [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447), [CVE-2026-7383](https://nvd.nist.gov/vuln/detail/CVE-2026-7383), [CVE-2026-9076](https://nvd.nist.gov/vuln/detail/CVE-2026-9076), [CVE-2026-45445](https://nvd.nist.gov/vuln/detail/CVE-2026-45445), [CVE-2026-42764](https://nvd.nist.gov/vuln/detail/CVE-2026-42764), [CVE-2026-34183](https://nvd.nist.gov/vuln/detail/CVE-2026-34183), [CVE-2026-34180](https://nvd.nist.gov/vuln/detail/CVE-2026-34180), [CVE-2026-34181](https://nvd.nist.gov/vuln/detail/CVE-2026-34181)
 
 ### 0.25.2 (2026-06-05)
@@ -542,6 +544,7 @@ The Docker image for the Native Node is used for self-hosted node deployment wit
 ### 0.25.3 (2026-06-22)
 
 * Improved [MCP (Model Context Protocol)](../../api-discovery/exploring.md#mcp-servers) traffic analysis logging — the Node no longer produces excessive log output when there is no MCP traffic
+* Changed the [Limit data export](../admin-en/export-to-cloud.md) rule — when applied, the node now preserves the request structure (parameter names and nesting) and masks only the values, instead of switching the matched traffic to metadata only
 * Fixed security vulnerabilities: [CVE-2026-34182](https://nvd.nist.gov/vuln/detail/CVE-2026-34182), [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447), [CVE-2026-7383](https://nvd.nist.gov/vuln/detail/CVE-2026-7383), [CVE-2026-9076](https://nvd.nist.gov/vuln/detail/CVE-2026-9076), [CVE-2026-45445](https://nvd.nist.gov/vuln/detail/CVE-2026-45445), [CVE-2026-42764](https://nvd.nist.gov/vuln/detail/CVE-2026-42764), [CVE-2026-34183](https://nvd.nist.gov/vuln/detail/CVE-2026-34183), [CVE-2026-34180](https://nvd.nist.gov/vuln/detail/CVE-2026-34180), [CVE-2026-34181](https://nvd.nist.gov/vuln/detail/CVE-2026-34181)
 
 ### 0.25.2 (2026-06-05)

--- a/docs/latest/updating-migrating/native-node/node-artifact-versions.md
+++ b/docs/latest/updating-migrating/native-node/node-artifact-versions.md
@@ -10,6 +10,10 @@ History of all-in-one installer updates simultaneously applies to it's x86_64 an
 
 [How to upgrade](all-in-one.md)
 
+### 0.25.3 (2026-06-22)
+
+* Improved [MCP (Model Context Protocol)](../../api-discovery/exploring.md#mcp-servers) traffic analysis logging — the Node no longer produces excessive log output when there is no MCP traffic
+
 ### 0.25.2 (2026-06-05)
 
 * Fixed issues with caching MCP schemas for schema enforcement
@@ -281,6 +285,11 @@ The Helm chart for the Native Node is used for self-hosted node deployments with
 
 [How to upgrade](helm-chart.md)
 
+### 0.25.3 (2026-06-22)
+
+* Improved [MCP (Model Context Protocol)](../../api-discovery/exploring.md#mcp-servers) traffic analysis logging — the Node no longer produces excessive log output when there is no MCP traffic
+* Fixed security vulnerabilities: [CVE-2026-34182](https://nvd.nist.gov/vuln/detail/CVE-2026-34182), [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447), [CVE-2026-7383](https://nvd.nist.gov/vuln/detail/CVE-2026-7383), [CVE-2026-9076](https://nvd.nist.gov/vuln/detail/CVE-2026-9076), [CVE-2026-45445](https://nvd.nist.gov/vuln/detail/CVE-2026-45445), [CVE-2026-42764](https://nvd.nist.gov/vuln/detail/CVE-2026-42764), [CVE-2026-34183](https://nvd.nist.gov/vuln/detail/CVE-2026-34183), [CVE-2026-34180](https://nvd.nist.gov/vuln/detail/CVE-2026-34180), [CVE-2026-34181](https://nvd.nist.gov/vuln/detail/CVE-2026-34181)
+
 ### 0.25.2 (2026-06-05)
 
 * Fixed issues with caching MCP schemas for schema enforcement
@@ -529,6 +538,11 @@ The Helm chart for the Native Node is used for self-hosted node deployments with
 The Docker image for the Native Node is used for self-hosted node deployment with the [connectors](../../installation/nginx-native-node-internals.md#connectors_1).
 
 [How to upgrade](docker-image.md)
+
+### 0.25.3 (2026-06-22)
+
+* Improved [MCP (Model Context Protocol)](../../api-discovery/exploring.md#mcp-servers) traffic analysis logging — the Node no longer produces excessive log output when there is no MCP traffic
+* Fixed security vulnerabilities: [CVE-2026-34182](https://nvd.nist.gov/vuln/detail/CVE-2026-34182), [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447), [CVE-2026-7383](https://nvd.nist.gov/vuln/detail/CVE-2026-7383), [CVE-2026-9076](https://nvd.nist.gov/vuln/detail/CVE-2026-9076), [CVE-2026-45445](https://nvd.nist.gov/vuln/detail/CVE-2026-45445), [CVE-2026-42764](https://nvd.nist.gov/vuln/detail/CVE-2026-42764), [CVE-2026-34183](https://nvd.nist.gov/vuln/detail/CVE-2026-34183), [CVE-2026-34180](https://nvd.nist.gov/vuln/detail/CVE-2026-34180), [CVE-2026-34181](https://nvd.nist.gov/vuln/detail/CVE-2026-34181)
 
 ### 0.25.2 (2026-06-05)
 


### PR DESCRIPTION
* Add 0.25.3 changelog entries for All-in-one installer, Helm chart, and Docker image: reduced MCP traffic analysis logging when no MCP traffic is present
* List fixed HIGH/CRITICAL OpenSSL CVEs (3.5.6-r0 -> 3.5.7-r0) for the Helm chart and Docker image (excluded from AIO: OS-level packages)
* Bump 0.25.2 -> 0.25.3 across Native Node install/usage references