### PR TITLE
docs: clarify proxy_headers real_ip and trusted_networks behavior

### DIFF
--- a/docs/latest/installation/native-node/all-in-one-conf.md
+++ b/docs/latest/installation/native-node/all-in-one-conf.md
@@ -639,9 +639,11 @@ Configures how the Native Node extracts the original client IP and host when tra
 
 * `trusted_networks`: trusted proxy IP ranges (CIDRs). Headers like `X-Forwarded-For` are only trusted if the request comes from these networks.
 
+    Specify only the network directly in front of the Node — the address seen as the remote IP before any proxy headers are evaluated.
+
     If omitted, all networks are trusted (not recommended).
 * `original_host`: headers to use for the original `Host` value, if modified by a proxy.
-* `real_ip`: headers to use for extracting the real client IP address.
+* `real_ip`: headers to use for extracting the real client IP address. If a header holds multiple comma-separated values, the first one is used.
 
 You can define multiple rules for different proxy types or trust levels.
 

--- a/docs/latest/installation/native-node/helm-chart-conf.md
+++ b/docs/latest/installation/native-node/helm-chart-conf.md
@@ -393,9 +393,11 @@ Configures how the Native Node extracts the original client IP and host when tra
 
 * `trusted_networks`: trusted proxy IP ranges (CIDRs). Headers like `X-Forwarded-For` are only trusted if the request comes from these networks.
 
+    Specify only the network directly in front of the Node — the address seen as the remote IP before any proxy headers are evaluated.
+
     If omitted, all networks are trusted (not recommended).
 * `original_host`: headers to use for the original `Host` value, if modified by a proxy.
-* `real_ip`: headers to use for extracting the real client IP address.
+* `real_ip`: headers to use for extracting the real client IP address. If a header holds multiple comma-separated values, the first one is used.
 
 You can define multiple rules for different proxy types or trust levels.
 


### PR DESCRIPTION
Document that real_ip uses the first value when a header holds multiple comma-separated values, and that trusted_networks needs only the network directly in front of the Node, not every device in the request chain.