### PR TITLE
API Discovery overview: clarify Content-type validation allows missing header

### DIFF
--- a/docs/latest/api-discovery/overview.md
+++ b/docs/latest/api-discovery/overview.md
@@ -101,6 +101,8 @@ Also, API Discovery performs filtering of requests relying on the other criteria
     * `application/octet-stream`
     * `application/*xml` (any XML variant)
 
+    Responses without a `Content-type` header, and the corresponding requests that also carry no `Content-type` header, are considered valid as well.
+
     This type of validation is only performed if enabled (see [how to check](setup.md#general-api-discovery-settings)) by the Wallarm support team, except cases when presence of file extension in the path makes it mandatory. The necessity of this validation in noise reduction depends on the peculiarities of your traffic.
 
 1. **Security filtering** - the following is not processed:


### PR DESCRIPTION
## What

Fixes a discrepancy in **API Security → API Discovery → Overview → Noise detection**, core filtering criteria item 6 (*Content-type header validation*).

The list of valid content types did not mention that responses **without any `Content-type` header** — and their corresponding requests that also carry no `Content-type` header — are treated as valid as well. This behavior is correct in the product but was missing from the docs.

## Change

Added one clarifying sentence to the Content-type header validation criterion in `docs/latest/api-discovery/overview.md`.

Production location: https://docs.wallarm.com/api-discovery/overview/#noise-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)