### PR TITLE
docs: add NGINX Node 6.13.0 release notes and bump versions

### DIFF
--- a/docs/6.x/admin-en/chaining-wallarm-and-other-ingress-controllers.md
+++ b/docs/6.x/admin-en/chaining-wallarm-and-other-ingress-controllers.md
@@ -103,7 +103,7 @@ To deploy the Wallarm Ingress controller and chain it with additional controller
     To learn more configuration options, please use the [link](configure-kubernetes-en.md).
 1. Install the Wallarm Ingress Helm chart:
     ``` bash
-    helm install --version 6.12.7 internal-ingress wallarm/wallarm-ingress -n wallarm-ingress -f values.yaml --create-namespace
+    helm install --version 6.13.0 internal-ingress wallarm/wallarm-ingress -n wallarm-ingress -f values.yaml --create-namespace
     ```
 
     * `internal-ingress` is the name of Helm release

--- a/docs/6.x/admin-en/configure-parameters-en.md
+++ b/docs/6.x/admin-en/configure-parameters-en.md
@@ -426,6 +426,19 @@ Possible values are `on` (response analysis is enabled) and `off` (response anal
 !!! warning "Improve performance"
     You are recommended to disable processing of static files through `location` to improve performance.
 
+### wallarm_parse_sse
+
+Controls whether the Node parses Server-Sent Events (SSE) response streams for response-side inspection.
+
+Responses with the `Content-type: text/event-stream` header are recognized as SSE streams automatically. When parsing is enabled, the Node reads the streamed events and passes them to response analysis. This is required for [API Discovery](../api-discovery/overview.md) and response-based detection on [MCP servers](../api-discovery/exploring.md#mcp-servers) that stream their responses over SSE.
+
+Available starting from release 6.13.0.
+
+!!! info
+    Default value is `on`.
+
+    This parameter can be set inside the http, server, and location blocks.
+
 ### wallarm_parse_websocket <a href="../../about-wallarm/subscription-plans/#core-subscription-plans"><img src="../../images/api-security-tag.svg"></a>
 
 Wallarm provides full WebSockets support under the API Security subscription plan. By default, the WebSockets' messages are not analyzed for attacks.

--- a/docs/6.x/admin-en/configure-wallarm-mode.md
+++ b/docs/6.x/admin-en/configure-wallarm-mode.md
@@ -52,7 +52,7 @@ Note that the described configuration is applicable only for [in-line](../instal
     When deploying the NGINX-based Wallarm nodes via docker containers, [pass](../admin-en/installation-docker-en.md#run-the-container-passing-the-environment-variables) the `WALLARM_MODE` environment variable:
 
     ```
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_MODE='monitoring' -p 80:80 wallarm/node:6.12.7
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_MODE='monitoring' -p 80:80 wallarm/node:6.13.0
     ```
 
     Alternatively, [include](../admin-en/installation-docker-en.md#run-the-container-mounting-the-configuration-file) the corresponding parameter in the configuration file and run the container mounting this file.

--- a/docs/6.x/admin-en/installation-docker-en.md
+++ b/docs/6.x/admin-en/installation-docker-en.md
@@ -63,11 +63,11 @@ To run the container:
 
     === "US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.13.0
         ```
     === "EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -p 80:80 wallarm/node:6.13.0
         ```
 
 You can pass the following basic filtering node settings to the container via the option `-e`:
@@ -97,11 +97,11 @@ To run the container:
 
     === "US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.13.0
         ```
     === "EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:6.13.0
         ```
 
     * The `-e` option passes the following required environment variables to the container:

--- a/docs/6.x/admin-en/installation-kubernetes-en.md
+++ b/docs/6.x/admin-en/installation-kubernetes-en.md
@@ -120,7 +120,7 @@ To install the Wallarm Ingress Controller:
 1. Install the Wallarm packages:
 
     ``` bash
-    helm install --version 6.12.7 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
+    helm install --version 6.13.0 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name for the Helm release of the Ingress controller chart

--- a/docs/6.x/admin-en/installation-postanalytics-en.md
+++ b/docs/6.x/admin-en/installation-postanalytics-en.md
@@ -30,11 +30,11 @@ To download all-in-one Wallarm installation script, execute the command:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.x86_64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.x86_64-glibc.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.aarch64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.aarch64-glibc.sh
     ```
 
 ## Step 2: Prepare Wallarm token
@@ -62,13 +62,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh postanalytics
     ```        
 
     The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -77,13 +77,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo sh wallarm-6.12.7.x86_64-glibc.sh postanalytics
+    sudo sh wallarm-6.13.0.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo sh wallarm-6.12.7.aarch64-glibc.sh postanalytics
+    sudo sh wallarm-6.13.0.aarch64-glibc.sh postanalytics
     ```
 
 ## Step 4: Configure the postanalytics module
@@ -167,13 +167,13 @@ Once the postanalytics module is installed on the separate server:
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -182,13 +182,13 @@ Once the postanalytics module is installed on the separate server:
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.x86_64-glibc.sh filtering
+        sudo sh wallarm-6.13.0.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.aarch64-glibc.sh filtering
+        sudo sh wallarm-6.13.0.aarch64-glibc.sh filtering
         ```
 
 ## Step 8: Connect the NGINX-Wallarm module to the postanalytics module

--- a/docs/6.x/api-discovery/overview.md
+++ b/docs/6.x/api-discovery/overview.md
@@ -1,1 +1,228 @@
---8<-- "latest/api-discovery/overview.md"
+# API Discovery Overview <a href="../../about-wallarm/subscription-plans/#core-subscription-plans"><img src="../../images/api-security-tag.svg" class="non-zoomable" style="border: none;"></a>
+
+Wallarm's multi-protocol API Discovery continuously analyzes the real traffic requests and builds the API inventory (full picture of your active APIs and MCP servers) based on the analysis results.
+
+## Supported protocols
+
+API Discovery is capable of finding and representing hosts and endpoints utilizing different protocols. The following protocols are supported:
+
+| Protocol | Core entity | Required [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) version | Required [Native Node](../installation/nginx-native-node-internals.md#native-node) version |
+| --- | --- | --- | --- |
+| **REST** | Endpoint | Any | Any |
+| **GraphQL** | Operation (query, mutation, subscription) | 6.1.0 | 0.15.1 |
+| **SOAP** | Operation | 6.3.0 | 0.17.1 |
+| **gRPC** | Operation | 6.4.0 | NA |
+| **MCP** | MCP server | 6.12.0 | 0.25.0 |
+
+## Your API inventory
+
+API inventory is a picture of your active APIs automatically built by Wallarm's API Discovery based on traffic going through Wallarm nodes. It includes:
+
+* API hosts and their endpoints
+* Required and optional parameters and headers of requests and responses including:
+
+    * Type and format of data sent in each parameter    
+    * Date and time when parameter information was last updated
+
+* Request methods (GET, POST, and others) for REST
+* GraphQL operations (queries, mutations, subscriptions)
+* GraphQL schema
+* SOAP operations
+* gRPC operations
+* MCP servers and their tools, resources, and prompts
+
+=== "APIs"
+    ![API Discovery - built API inventory](../images/about-wallarm-waf/api-discovery-2.0/api-discovery-built-inventory.png)
+=== "MCP Servers"
+    ![Discovered MCP Servers](../images/about-wallarm-waf/api-discovery-2.0/api-discovery-mcp-servers.png)
+
+## Issues addressed by API Discovery
+
+**Building an actual and complete API inventory** is the main issue the API Discovery module is addressing.
+
+Keeping API inventory up-to-date is a difficult task. There is a high chance that one API is used by multiple teams and clients and it is a common case that different tools and processes are used to produce the API documentation. As a result, companies struggle both to understand what APIs they have and what data they expose, and to keep API documentation up to date.
+
+Since the API Discovery module uses the real traffic as a data source, it helps to get up-to-date and complete API documentation by including in the API inventory all endpoints that are actually processing the requests.
+
+**As you have your API inventory discovered by Wallarm, you can**:
+
+* Have full visibility into the whole API estate.
+* See what data ([REST](exploring.md#rest-endpoint-details), [GraphQL](exploring.md#graphql-operation-details), [SOAP](exploring.md#soap-operation-details), [gRPC](exploring.md#grpc-operation-details)) is going into and out of the APIs.
+* Filter APIs that consume and carry [sensitive data](#sensitive-data-detection).
+* Filter APIs that have no [authentication](exploring.md#authentication-flow).
+* Understand which endpoints are [most likely](risk-score.md) to be an attack target.
+* Find endpoints that have [security issues](../api-attack-surface/security-issues.md) (vulnerabilities) and navigate from endpoint details to full descriptions and mitigation methods.
+* [Track changes](track-changes.md) in API that took place within the selected period of time.
+* Provide your developers with [access](../user-guides/settings/users.md#user-roles) to review and download the built API inventory.
+<!--* Get a list of the threats that occurred over the past 7 days per any given API endpoint.-->
+
+## How does API Discovery work?
+
+API Discovery relies on request statistics and uses sophisticated algorithms to generate up-to-date API specs based on the actual API usage.
+
+### Traffic processing
+
+API Discovery uses a hybrid approach to conduct analysis locally and in the Cloud. This approach enables a [privacy-first process](#security-of-data-uploaded-to-the-wallarm-cloud) where request data and sensitive data are kept locally while using the power of the Cloud for the statistics analysis:
+
+1. API Discovery analyzes legitimate traffic locally — it inspects which endpoints are requested and what parameters are passed in requests and responses.
+
+    For REST, GraphQL, SOAP, and gRPC, the node sends ~10% of responses for analysis. For MCP, it sends 100% to ensure complete capture of tool schemas from `tools/list`, `resources/list`, and `prompts/list` responses.
+1. According to this data, statistics are made and sent to the Cloud.
+1. Wallarm Cloud aggregates the received statistics and builds an [API description](exploring.md) on its basis.
+
+    !!! info "Noise detection"
+        Rare or single requests are [determined as noise](#noise-detection) and not included in the API inventory.
+
+### Noise detection
+
+The API Discovery module bases noise detection on the two major traffic parameters:
+
+* **Endpoint stability** - at least a specific **number of requests** should be registered for the endpoint for it to be displayed by API Discovery AND at least one of them must be outside the **timeframe**.
+
+    These settings aim to avoid showing API entries that had no traffic or had traffic for a short timeframe only - they are considered unstable. Even if the specific endpoint was requested a huge amount of times, but just within a short timeframe, there is no need to consider this one-time spike as a stable API endpoint.
+
+    ![API Discovery - endpoint stability](../images/about-wallarm-waf/api-discovery/api-discovery-endpoint-stability.png)
+
+* **Parameter stability** - the occurrence of the parameter in requests to the endpoint must be more than 1 percent.
+
+Also, API Discovery performs filtering of requests relying on the other criteria, described in the sections below. Note that the time required to build the complete API inventory depends on the traffic diversity and intensity.
+
+#### Core filtering criteria
+
+1. **HTTP status code validation** - only requests with server responses in the `2xx` range (`200`-`299`) are processed.
+1. **HTTP method validation** - requests must use valid HTTP methods. The following is not processed: empty method, `OPTIONS`, `HEAD`.
+1. **Host validation** - requests must not target localhost or loopback addresses. The following is not processed: `localhost`, `127.0.0.1`, IPv6 loopback addresses (`::1`, `0:0:0:0:0:0:0:1`, etc.)
+1. **Path validation** - request paths must conform to valid patterns: `^[\w{}\s\-]+(?:[.@][\w{}\s\-]+)*$`. The following is not processed: paths containing CJK characters (Unicode range 0x3000-0x303F).
+1. **File extension filtering** - requests with file extensions are filtered based on content type validation: when a path has an extension, the `Content-type` header validation becomes mandatory.
+1. **Content-type header validation** - the `Content-type` header of response must be valid:
+
+    * `text/xml`
+    * `application/*json` (any JSON variant)
+    * `application/octet-stream`
+    * `application/*xml` (any XML variant)
+
+    Responses without a `Content-type` header, and the corresponding requests that also carry no `Content-type` header, are considered valid as well.
+
+    This type of validation is only performed if enabled (see [how to check](setup.md#general-api-discovery-settings)) by the Wallarm support team, except cases when presence of file extension in the path makes it mandatory. The necessity of this validation in noise reduction depends on the peculiarities of your traffic.
+
+1. **Security filtering** - the following is not processed:
+
+    * Requests with [attack types](../attacks-vulns-list.md)
+    * Requests from DirBuster and similar scanners
+
+#### Protocol-specific criteria
+
+##### GraphQL
+
+**Detection method**: analyzes request payload structure for GraphQL-specific patterns.
+**Key indicators**:
+
+* GraphQL structure in any HTTP valid request type (`GET`, `POST`)
+* Operation types: `query`, `mutation`, `subscription`
+
+**Response pattern**: only JSON object with structure `{"data":{}}`.
+
+##### SOAP
+
+**Detection method**: analyzes XML structure for SOAP envelope patterns.
+**Key indicators**:
+
+* XML structure with SOAP envelope
+* Must contain proper SOAP namespace structure
+
+**Requirements**:
+
+* Must have SOAP envelope with proper namespace
+* Must contain SOAP Body element
+* Must have a method name as the final element
+
+##### gRPC
+
+**Detection method**: analyzes HTTP/2 requests with `application/grpc` content type.
+**Key indicators**:
+
+* HTTP/2 protocol with `application/grpc` content type
+* Protocol buffer encoded payload
+
+Only general gRPC services that use [protocol buffers](https://protobuf.dev/) are discovered.
+
+##### MCP
+
+**Detection method**: analyzes JSON-RPC 2.0 request/response structure for patterns specific to the [Model Context Protocol](https://modelcontextprotocol.io/), such as MCP-specific method names and protocol headers. For instance, `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, etc.
+
+Once an MCP server endpoint is discovered, API Discovery captures the server's primitives:
+
+* **Tools** — invocable functions exposed by the MCP server (e.g., `get_user_profile`, `create_lead`)
+* **Resources** — data and files available for reading (e.g., `crm://legal/nda`)
+* **Prompts** — parametrized templates for common workflows (e.g., `account_research_prompt`)
+
+Service methods such as `ping`, `resources/subscribe`, `completion/complete`, and `logging/setLevel` are automatically filtered out and do not appear as discovered primitives.
+
+The Node automatically enables 100% response parsing for discovered MCP endpoints to ensure complete schema capture.
+
+Many MCP servers return their responses as Server-Sent Events (SSE) streams (`Content-type: text/event-stream`) rather than a single JSON body. Starting from [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.13.0, the Node parses these SSE response streams, so tool, resource, and prompt schemas are captured from streamed responses as well.
+
+Discovered MCP servers are displayed in the API inventory with the **MCP** protocol label and can be used as a scope for [MCP mitigation controls](../agentic-ai/mcp-mitigation-controls.md).
+
+##### REST
+
+**Detection method**: default fallback for requests that don't match other patterns.
+**Key indicators**:
+
+* Does not match GraphQL, SOAP, gRPC
+* Uses standard HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, etc.)
+
+#### Additional filtering criteria
+
+1. **Multipart request filtering** - multipart requests with header parts are not processed.
+1. **Base64 content filtering** - request points ending with "base64" are excluded.
+1. **Empty value filtering** - request points with empty values are excluded in most contexts.
+
+### Authentication flow detection
+
+API Discovery automatically detects [authentication flows](authentication.md) used by each endpoint by analyzing HTTP headers and request parameters in the traffic. This helps identify endpoints that lack proper authentication — the #1 API security risk.
+
+![Authentication tab in endpoint details](../images/about-wallarm-waf/api-discovery-2.0/endpoint-auth-tab.png)
+
+### Sensitive data detection
+
+API Discovery [detects and highlights](sensitive-data.md) sensitive data consumed and carried by your APIs:
+
+* Personally identifiable information (PII) like full name, passport number or SSN
+* Login credentials like secret keys and passwords
+* Financial data like bank card numbers
+* Medical data like medical license number
+* Technical data like IP and MAC addresses
+
+### Sensitive business flows
+
+With the [sensitive business flow](sbf.md) capability, API Discovery can automatically identify endpoints that are critical to specific business flows and functions, such as authentication, account management, billing, and similar critical capabilities.
+
+In addition to automatic identification, you can manually adjust the assigned sensitive business flow tags and manually set tags for the endpoints of your choice.
+
+Once endpoints are assigned the sensitive business flow tags, it becomes possible to filter all discovered endpoints by a specific business flow, which makes it easier to protect the most critical business capabilities.
+
+![API Discovery - Filtering by sensitive business flows](../images/about-wallarm-waf/api-discovery-2.0/api-discovery-sbf-filter.png)
+
+### Security of data uploaded to the Wallarm Cloud
+
+API Discovery analyzes most of the traffic locally. The module sends to the Wallarm Cloud only the discovered endpoints, parameter names and various statistical data (time of arrival, their number, etc.) All data is transmitted via a secure channel: before uploading the statistics to the Wallarm Cloud, the API Discovery module hashes the values of request parameters using the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm.
+
+On the Cloud side, hashed data is used for statistical analysis (for example, when quantifying requests with identical parameters).
+
+Other data (endpoint values, request methods, and parameter names) is not hashed before being uploaded to the Wallarm Cloud, because hashes cannot be restored to their original state which would make building API inventory impossible.
+
+!!! warning "Important"
+    API Discovery does not send the parameter values to the Cloud. Only the endpoint, parameter names and statistics on them are sent.
+
+## Checking API Discovery in playground
+
+To try the module even before signing up and deploying the node to your environment, explore [API Discovery in Wallarm Playground](https://playground.wallarm.com/api-discovery/?utm_source=wallarm_docs_apid).
+
+In Playground, you can access the API Discovery view as if it were filled with real data and thus learn and try out how the module works, and get some useful examples of its usage in the read-only mode.
+
+![API Discovery – Sample Data](../images/about-wallarm-waf/api-discovery/api-discovery-sample-data.png)
+
+## Enabling API Discovery
+
+To start using API Discovery, enable it as described in [API Discovery Setup](setup.md).

--- a/docs/6.x/api-discovery/setup.md
+++ b/docs/6.x/api-discovery/setup.md
@@ -8,7 +8,7 @@ This article describes how to enable and configure Wallarm's [API Discovery](ove
 * For **GraphQL** - [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.1.0+ or [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.15.1+.
 * For **SOAP** - [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.3.0 or [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.17.1+.
 * For **gRPC** - [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.4.0 or higher (not supported by [Native Node](../installation/nginx-native-node-internals.md#native-node) so far)
-* For **MCP** - [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.12.0+ or [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.25.0+.
+* For **MCP** - [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.12.0+ or [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.25.0+. To analyze MCP servers that stream their responses as Server-Sent Events (SSE, `Content-type: text/event-stream`), [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.13.0+ is required.
 
 API Discovery is included in [all forms of the Wallarm node installation](../installation/supported-deployment-options.md). During node deployment, it installs the API Discovery module but keeps it disabled by default.
 

--- a/docs/6.x/api-sessions/mcp-sessions.md
+++ b/docs/6.x/api-sessions/mcp-sessions.md
@@ -1,1 +1,86 @@
---8<-- "latest/api-sessions/mcp-sessions.md"
+# MCP Sessions <a href="../../about-wallarm/subscription-plans/#core-subscription-plans"><img src="../../images/api-security-tag.svg" class="non-zoomable" style="border: none;"></a>
+
+In addition to regular [API Sessions](overview.md), Wallarm provides dedicated support for [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) sessions. MCP sessions group MCP tool calls, resource reads, and prompt invocations into logical sessions, giving you visibility into how AI agents interact with MCP servers.
+
+MCP sessions are displayed in a dedicated **MCP Sessions** tab in Wallarm Console → **API Sessions**.
+
+![Discovered MCP Sessions](../images/api-sessions/mcp-sessions.png)
+
+## How MCP Sessions work
+
+When Wallarm detects MCP traffic (JSON-RPC 2.0 requests with MCP-specific methods), it groups requests into sessions based on the `MCP-SESSION-ID` header — a standard MCP protocol header that identifies a session.
+
+For each MCP session, Wallarm displays:
+
+* **MCP server** — the host and path of the MCP server endpoint
+* **Session ID** — the value of the `MCP-SESSION-ID` header
+* **User** and **Role** — extracted from session context if [configured](#mcp-session-configuration)
+* **Methods** — MCP methods called during the session (`tools/call`, `resources/read`, `prompts/get`, etc.)
+* **Primitives** — names of tools, resources, or prompts accessed during the session
+* **Attacks** — any attacks detected within the session by [MCP mitigation controls](../agentic-ai/mcp-mitigation-controls.md) or other protection mechanisms
+
+You can click on any session to see the full request sequence, with each request showing its MCP method, primitive name, and request/response details.
+
+## Requirements
+
+* The [Advanced API Security](../about-wallarm/subscription-plans.md#core-subscription-plans) subscription plan
+* [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.12.0 or higher, or [Native Node](../installation/nginx-native-node-internals.md#native-node) 0.25.0 or higher
+
+    Some MCP servers return their responses as Server-Sent Events (SSE) streams (`Content-type: text/event-stream`) rather than a single JSON body. To inspect these streamed responses, [NGINX Node](../installation/nginx-native-node-internals.md#nginx-node) 6.13.0 or higher is required.
+
+## MCP Session Configuration
+
+MCP sessions are detected automatically — the Wallarm node recognizes MCP traffic by JSON-RPC 2.0 patterns and groups requests into sessions using the standard `MCP-SESSION-ID` header. No manual configuration is required for basic MCP session detection.
+
+When [API Discovery](../api-discovery/overview.md) detects an MCP server, it automatically creates an MCP Session Configuration with default rules (extracting session ID from the `MCP-SESSION-ID` header). You can view and customize these auto-created configurations or create new ones manually.
+
+You can optionally add **MCP session context parameters** to extract additional information from MCP traffic, such as user identity and role. This enables:
+
+* User and role display in MCP session details
+* Filtering MCP sessions by user or role
+* User- and role-based [ACL policies](../agentic-ai/mcp-mitigation-controls.md#acl-policy)
+
+!!! info "MCP user and role"
+    MCP sessions have their own user and role, separate from the HTTP-level user. A single AI agent may interact with multiple MCP servers using different identities. The extracted MCP user and role are written into the standard session user/role fields for display and filtering.
+
+To configure MCP session context parameters:
+
+1. Go to Wallarm Console → **API Sessions** → click **Session context parameters**.
+1. Switch to the **MCP Sessions** tab.
+1. Select an existing MCP server (auto-created by [API Discovery](../api-discovery/exploring.md#mcp-servers)) or click **Add MCP Session config** to add a new one manually. For a new server, specify:
+    * **Host** — the hostname of your MCP server (e.g., `mcp.example.com`)
+    * **Location** — the path to the MCP endpoint (e.g., `/mcp` or `/sse`)
+1. Within the selected MCP server configuration, add context parameters. Each parameter specifies a request/response location and its type:
+
+    | Type | Description |
+    |---|---|
+    | **MCP Session ID** | Location of the session identifier. By default, the node uses the `MCP-SESSION-ID` header. Set this only if your MCP server uses a non-standard session ID location. |
+    | **MCP User** | Location of the user identifier (e.g., a JWT claim or a custom header). |
+    | **MCP Role** | Location of the user role (e.g., a JWT claim). |
+
+1. Click **Save**.
+
+## Exploring MCP Sessions
+
+MCP sessions can be explored in the **MCP Sessions** tab in Wallarm Console → **API Sessions**. Like regular API sessions, MCP sessions are split into daily parts and stored for 7 days. The tab provides the same capabilities as regular API Sessions (except CSV export, which is not available for MCP sessions):
+
+* Filter sessions by time range, user, role, MCP server, or attack type
+* View the full sequence of requests within a session
+* Inspect request and response details for each MCP call
+* Navigate to the attack details and the mitigation control that triggered detection
+
+When viewing request details within an MCP session, the following MCP-specific information is displayed:
+
+* **MCP method** — the JSON-RPC method (e.g., `tools/call`, `resources/read`)
+* **Primitive name** — the tool, resource, or prompt name
+* **Arguments** — the parameters passed to the tool call (for `tools/call` requests)
+
+![MCP session details](../images/api-sessions/mcp-session-details.png)
+
+## Viewing attacks in MCP Sessions
+
+Attacks detected by [MCP mitigation controls](../agentic-ai/mcp-mitigation-controls.md) are displayed directly within the MCP session where they occurred. In the request details, you can see:
+
+* The attack type (**ACL violation**, **MCP request verification failure**, **Invalid tool call**)
+* A link to the mitigation control that triggered the detection
+* The full request content that caused the violation

--- a/docs/6.x/installation/cloud-platforms/alibaba-cloud/docker-container.md
+++ b/docs/6.x/installation/cloud-platforms/alibaba-cloud/docker-container.md
@@ -69,11 +69,11 @@ To deploy the containerized Wallarm filtering node configured only through envir
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:6.13.0
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -p 80:80 wallarm/node:6.13.0
         ```
         
     * `-p`: port the filtering node listens to. The value should be the same as the instance port.
@@ -133,11 +133,11 @@ To deploy the containerized Wallarm filtering node configured through environmen
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.13.0
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.13.0
         ```
 
     * `<INSTANCE_PATH_TO_CONFIG>`: path to the configuration file created in the previous step. For example, `configs`.

--- a/docs/6.x/installation/cloud-platforms/aws/docker-container.md
+++ b/docs/6.x/installation/cloud-platforms/aws/docker-container.md
@@ -147,7 +147,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.7"
+                "image": "registry-1.docker.io/wallarm/node:6.13.0"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -185,7 +185,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.7"
+                "image": "registry-1.docker.io/wallarm/node:6.13.0"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -320,7 +320,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.7"
+                "image": "registry-1.docker.io/wallarm/node:6.13.0"
                 }
             ],
             "volumes": [
@@ -369,7 +369,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:6.12.7"
+                "image": "registry-1.docker.io/wallarm/node:6.13.0"
                 }
             ],
             "volumes": [
@@ -466,7 +466,7 @@ To avoid this, authenticate ECS tasks to Docker Hub using a paid Docker Hub acco
     "containerDefinitions": [
         {
             "name": "wallarm-container",
-            "image": "registry-1.docker.io/wallarm/node:6.12.7",
+            "image": "registry-1.docker.io/wallarm/node:6.13.0",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:<DOCKER_HUB_SECRET_NAME>"
             },

--- a/docs/6.x/installation/cloud-platforms/azure/docker-container.md
+++ b/docs/6.x/installation/cloud-platforms/azure/docker-container.md
@@ -84,7 +84,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.7 \
+            --image registry-1.docker.io/wallarm/node:6.13.0 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_API_HOST='us1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
          ```
     === "Command for the Wallarm EU Cloud"
@@ -94,7 +94,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.7 \
+            --image registry-1.docker.io/wallarm/node:6.13.0 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_LABELS='group=<GROUP>'
          ```
 
@@ -172,7 +172,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.7 \
+            --image registry-1.docker.io/wallarm/node:6.13.0 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_API_HOST='us1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
@@ -184,7 +184,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:6.12.7 \
+            --image registry-1.docker.io/wallarm/node:6.13.0 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_LABELS='group=<GROUP>'

--- a/docs/6.x/installation/cloud-platforms/gcp/docker-container.md
+++ b/docs/6.x/installation/cloud-platforms/gcp/docker-container.md
@@ -69,7 +69,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
             --container-env WALLARM_API_HOST=us1.api.wallarm.com \
-            --container-image registry-1.docker.io/wallarm/node:6.12.7
+            --container-image registry-1.docker.io/wallarm/node:6.13.0
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
@@ -78,7 +78,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --tags http-server \
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
-            --container-image registry-1.docker.io/wallarm/node:6.12.7
+            --container-image registry-1.docker.io/wallarm/node:6.13.0
         ```
 
     * `<INSTANCE_NAME>`: name of the instance, for example: `wallarm-node`.
@@ -153,11 +153,11 @@ To deploy the containerized Wallarm filtering node configured through environmen
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:6.13.0
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.12.7
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:6.13.0
         ```
 
     * `<INSTANCE_PATH_TO_CONFIG>`: path to the configuration file created in the previous step. For example, `configs`.

--- a/docs/6.x/installation/heroku/docker-image.md
+++ b/docs/6.x/installation/heroku/docker-image.md
@@ -347,7 +347,7 @@ To deploy Wallarm's Docker image on Heroku, start by creating the necessary conf
     ```dockerfile
     FROM ubuntu:22.04
 
-    ARG VERSION="6.12.7"
+    ARG VERSION="6.13.0"
 
     ENV PORT=3000
     ENV WALLARM_LABELS="group=heroku"
@@ -404,10 +404,10 @@ To deploy Wallarm's Docker image on Heroku, start by creating the necessary conf
 Execute the following commands within the previously created directory:
 
 ```
-docker build -t wallarm-heroku:6.12.7 .
+docker build -t wallarm-heroku:6.13.0 .
 docker login
-docker tag wallarm-heroku:6.12.7 <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.7
-docker push <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.7
+docker tag wallarm-heroku:6.13.0 <DOCKERHUB_USERNAME>/wallarm-heroku:6.13.0
+docker push <DOCKERHUB_USERNAME>/wallarm-heroku:6.13.0
 ```
 
 ## Step 3: Run the built Docker image on Heroku
@@ -418,7 +418,7 @@ To deploy the image on Heroku:
 1. Construct a `Dockerfile` which will include the installation of necessary dependencies specific to your app's runtime. For a Node.js application, use the following template:
 
     ```dockerfile
-    FROM <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.7
+    FROM <DOCKERHUB_USERNAME>/wallarm-heroku:6.13.0
 
     ENV NODE_MAJOR=20
 

--- a/docs/6.x/installation/kubernetes/sidecar-proxy/deployment.md
+++ b/docs/6.x/installation/kubernetes/sidecar-proxy/deployment.md
@@ -118,7 +118,7 @@ Generate a filtering node token of the [appropriate type][node-token-types] to c
 1. Deploy the Wallarm Helm chart:
 
     ``` bash
-    helm install --version 6.12.7 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar --create-namespace -f <PATH_TO_VALUES>
+    helm install --version 6.13.0 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar --create-namespace -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name for the Helm release of the Wallarm Sidecar chart

--- a/docs/6.x/installation/nginx-compatibility.md
+++ b/docs/6.x/installation/nginx-compatibility.md
@@ -12,6 +12,7 @@ For the exact version added in a specific release, see the [NGINX Node changelog
 
 | Node version   | NGINX stable      | NGINX mainline    | NGINX Plus    |
 |----------------|-------------------|-------------------|---------------|
+| 6.13.0         | 1.30.4 and below  | 1.31.3 and below  | R37 and below |
 | 6.12.6–6.12.7  | 1.30.3 and below  | 1.31.2 and below  | R37 and below |
 | 6.12.5         | 1.30.2 and below  | 1.31.1 and below  | R37 and below |
 | 6.12.4         | 1.30.2 and below  | 1.31.1 and below  | R35 and below |

--- a/docs/6.x/updating-migrating/docker-container.md
+++ b/docs/6.x/updating-migrating/docker-container.md
@@ -31,7 +31,7 @@ To upgrade the end‑of‑life node (3.6 or lower), please use the [different in
 ## Step 1: Download the updated filtering node image
 
 ``` bash
-docker pull wallarm/node:6.12.7
+docker pull wallarm/node:6.13.0
 ```
 
 ## Step 2: Stop the running container

--- a/docs/6.x/updating-migrating/ingress-controller.md
+++ b/docs/6.x/updating-migrating/ingress-controller.md
@@ -44,7 +44,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.7 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.13.0 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>`: the name of the Helm release with the Ingress controller chart.
@@ -65,7 +65,7 @@ To install and run the plugin:
 Upgrade the deployed NGINX Ingress controller:
 
 ``` bash
-helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.7 -f <PATH_TO_VALUES>
+helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.13.0 -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>`: the name of the Helm release with the Ingress controller chart
@@ -84,7 +84,7 @@ helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.1
 
     Where `<NAMESPACE>` is the namespace the Helm chart with the Ingress controller is deployed to.
 
-    The chart version should correspond to `wallarm-ingress-6.12.7`.
+    The chart version should correspond to `wallarm-ingress-6.13.0`.
 1. Get the Wallarm pod:
     
     ``` bash

--- a/docs/6.x/updating-migrating/nginx-modules.md
+++ b/docs/6.x/updating-migrating/nginx-modules.md
@@ -90,13 +90,13 @@ To upgrade the end‑of‑life node (3.6 or lower), please use the [different in
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -105,13 +105,13 @@ To upgrade the end‑of‑life node (3.6 or lower), please use the [different in
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.x86_64-glibc.sh filtering
+        sudo sh wallarm-6.13.0.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.aarch64-glibc.sh filtering
+        sudo sh wallarm-6.13.0.aarch64-glibc.sh filtering
         ```
 
 ## Step 6: Transfer NGINX and postanalytics configuration from old node machine to new

--- a/docs/6.x/updating-migrating/node-artifact-versions.md
+++ b/docs/6.x/updating-migrating/node-artifact-versions.md
@@ -25,7 +25,7 @@ new attack types in logging variables and search bars?
 
 * Added support for NGINX stable 1.30.4
 * Added support for NGINX mainline 1.31.3
-* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Added Server-Sent Events (SSE) response analysis, enabled by default and controlled by the [`wallarm_parse_sse`](../admin-en/configure-parameters-en.md#wallarm_parse_sse) directive, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
 * Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 * Fixed security vulnerabilities:
 
@@ -309,7 +309,7 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 ### 6.13.0 (2026-07-29)
 
-* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Added Server-Sent Events (SSE) response analysis, enabled by default and controlled by the [`wallarm_parse_sse`](../admin-en/configure-parameters-en.md#wallarm_parse_sse) directive, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
 * Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 
 ### 6.12.7 (2026-06-26)
@@ -599,7 +599,7 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 ### 6.13.0 (2026-07-29)
 
-* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Added Server-Sent Events (SSE) response analysis, enabled by default and controlled by the [`wallarm_parse_sse`](../admin-en/configure-parameters-en.md#wallarm_parse_sse) directive, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
 * Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 
 ### 6.12.7 (2026-06-26)
@@ -860,7 +860,7 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 ### 6.13.0 (2026-07-29)
 
-* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Added Server-Sent Events (SSE) response analysis, enabled by default and controlled by the [`wallarm_parse_sse`](../admin-en/configure-parameters-en.md#wallarm_parse_sse) directive, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
 * Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 * Fixed security vulnerabilities:
 
@@ -1127,7 +1127,7 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 ### 6.13.0 (2026-07-29)
 
-* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Added Server-Sent Events (SSE) response analysis, enabled by default and controlled by the [`wallarm_parse_sse`](../admin-en/configure-parameters-en.md#wallarm_parse_sse) directive, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
 * Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 
 ### 6.12.7 (2026-06-26)
@@ -1348,7 +1348,7 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 ### wallarm-node-6-13-0-20260729-094623 (2026-07-29)
 
-* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Added Server-Sent Events (SSE) response analysis, enabled by default and controlled by the [`wallarm_parse_sse`](../admin-en/configure-parameters-en.md#wallarm_parse_sse) directive, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
 * Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 
 ### wallarm-node-6-12-7-20260625-060642 (2026-06-25)

--- a/docs/6.x/updating-migrating/node-artifact-versions.md
+++ b/docs/6.x/updating-migrating/node-artifact-versions.md
@@ -21,6 +21,17 @@ new loggin variable wallarm_block_reason
 new attack types in logging variables and search bars?
 -->
 
+### 6.13.0 (2026-07-29)
+
+* Added support for NGINX stable 1.30.4
+* Added support for NGINX mainline 1.31.3
+* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
+* Fixed security vulnerabilities:
+
+    * [CVE-2026-7246](https://nvd.nist.gov/vuln/detail/CVE-2026-7246)
+    * [GHSA-6v7p-g79w-8964](https://github.com/advisories/GHSA-6v7p-g79w-8964)
+
 ### 6.12.7 (2026-06-26)
 
 * Added support for the latest Ubuntu, Alpine, and Oracle Linux distribution NGINX packages
@@ -295,6 +306,11 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 ## Helm chart for Wallarm NGINX Ingress controller
 
 [How to upgrade](ingress-controller.md)
+
+### 6.13.0 (2026-07-29)
+
+* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 
 ### 6.12.7 (2026-06-26)
 
@@ -581,6 +597,11 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 [How to upgrade](sidecar-proxy.md)
 
+### 6.13.0 (2026-07-29)
+
+* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
+
 ### 6.12.7 (2026-06-26)
 
 * Added the [`wallarm_enable_mcp_global`](../admin-en/configure-parameters-en.md#wallarm_enable_mcp_global) directive to enable or disable downloading MCP rules and schemas from the Wallarm Cloud (enabled by default)
@@ -836,6 +857,15 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 ## NGINX-based Docker image
 
 [How to upgrade](docker-container.md)
+
+### 6.13.0 (2026-07-29)
+
+* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
+* Fixed security vulnerabilities:
+
+    * [CVE-2026-7246](https://nvd.nist.gov/vuln/detail/CVE-2026-7246)
+    * [GHSA-6v7p-g79w-8964](https://github.com/advisories/GHSA-6v7p-g79w-8964)
 
 ### 6.12.7 (2026-06-26)
 
@@ -1095,6 +1125,11 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 
 [How to upgrade](cloud-image.md)
 
+### 6.13.0 (2026-07-29)
+
+* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
+
 ### 6.12.7 (2026-06-26)
 
 * Added the [`wallarm_enable_mcp_global`](../admin-en/configure-parameters-en.md#wallarm_enable_mcp_global) directive to enable or disable downloading MCP rules and schemas from the Wallarm Cloud (enabled by default)
@@ -1310,6 +1345,11 @@ To mitigate the risk of the NGINX vulnerabilities [CVE-2026-42945](https://nvd.n
 ## Google Cloud Platform Image
 
 [How to upgrade](cloud-image.md)
+
+### wallarm-node-6-13-0-20260729-094623 (2026-07-29)
+
+* Added Server-Sent Events (SSE) analysis, improving discovery of [MCP servers](../api-discovery/exploring.md#mcp-servers)
+* Improved [DoS protection](../api-protection/dos-protection.md) mitigation control accuracy
 
 ### wallarm-node-6-12-7-20260625-060642 (2026-06-25)
 

--- a/docs/6.x/updating-migrating/older-versions/docker-container.md
+++ b/docs/6.x/updating-migrating/older-versions/docker-container.md
@@ -41,7 +41,7 @@ The module operation can cause [false positives](../../about-wallarm/protecting-
 ## Step 4: Download the updated filtering node image
 
 ``` bash
-docker pull wallarm/node:6.12.7
+docker pull wallarm/node:6.13.0
 ```
 
 ## Step 5: Switch to the token-based connection to the Wallarm Cloud

--- a/docs/6.x/updating-migrating/older-versions/ingress-controller.md
+++ b/docs/6.x/updating-migrating/older-versions/ingress-controller.md
@@ -209,7 +209,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.7 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.13.0 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>`: the name of the Helm release with the Ingress controller chart
@@ -316,7 +316,7 @@ By using this method, you can deploy Ingress Controller 6.x as an additional ent
 2. Deploy the Ingress controller 6.x:
 
     ```bash
-    helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.7 -f <PATH_TO_VALUES>
+    helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.13.0 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>`: the name for the Helm release of the Ingress controller chart
@@ -352,7 +352,7 @@ To re‑create the Ingress controller release:
     2. Create a new release with Ingress controller 6.x:
 
         ```bash
-        helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.7 -f <PATH_TO_VALUES>
+        helm install <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.13.0 -f <PATH_TO_VALUES>
         ```
 
         * `<RELEASE_NAME>`: the name for the Helm release of the Ingress controller chart
@@ -404,7 +404,7 @@ Release re‑creation will take several minutes and the Ingress controller will 
 
     ```bash
     cat objects-to-remove.txt | xargs kubectl delete --wait=false -n <NAMESPACE>    && \
-    helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.12.7 -f `<PATH_TO_VALUES>`
+    helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-ingress --version 6.13.0 -f `<PATH_TO_VALUES>`
     ```
 
     To decrease service downtime, it is NOT recommended to execute commands separately.
@@ -430,7 +430,7 @@ There are the following parameters passed in the commands:
     helm ls
     ```
 
-    The chart version should correspond to `wallarm-ingress-6.12.7`.
+    The chart version should correspond to `wallarm-ingress-6.13.0`.
 1. Get the Wallarm pod:
     
     ``` bash

--- a/docs/6.x/updating-migrating/older-versions/nginx-modules.md
+++ b/docs/6.x/updating-migrating/older-versions/nginx-modules.md
@@ -104,13 +104,13 @@ The module operation can cause [false positives](../../about-wallarm/protecting-
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -119,13 +119,13 @@ The module operation can cause [false positives](../../about-wallarm/protecting-
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.x86_64-glibc.sh filtering
+        sudo sh wallarm-6.13.0.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
         
         ```bash
-        sudo sh wallarm-6.12.7.aarch64-glibc.sh filtering
+        sudo sh wallarm-6.13.0.aarch64-glibc.sh filtering
         ```
 
 ## Step 7: Migrate allowlists and denylists from the previous Wallarm node version to 6.x (only if upgrading node 2.18 or lower)

--- a/docs/6.x/updating-migrating/older-versions/what-is-new.md
+++ b/docs/6.x/updating-migrating/older-versions/what-is-new.md
@@ -644,7 +644,7 @@ Now you can easily group node instances using one [**API token**](../../user-gui
 For example: 
 
 ```bash
-docker run -d -e WALLARM_API_TOKEN='<API TOKEN WITH DEPLOY ROLE>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_LABELS='group=<GROUP>' -p 80:80 wallarm/node:6.12.7
+docker run -d -e WALLARM_API_TOKEN='<API TOKEN WITH DEPLOY ROLE>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_LABELS='group=<GROUP>' -p 80:80 wallarm/node:6.13.0
 ```
 ...will place the node instance into the `<GROUP>` instance group (existing, or, if does not exist, it will be created).
 

--- a/docs/6.x/updating-migrating/sidecar-proxy.md
+++ b/docs/6.x/updating-migrating/sidecar-proxy.md
@@ -29,7 +29,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n wallarm-sidecar wallarm/wallarm-sidecar --version 6.12.7 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n wallarm-sidecar wallarm/wallarm-sidecar --version 6.13.0 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name of the Wallarm Sidecar Helm release.
@@ -64,7 +64,7 @@ kubectl delete secret <RELEASE_NAME>-wallarm-sidecar-admission-tls -n wallarm-si
 ### Step 5: Deploy the new solution version
 
 ``` bash
-helm install --version 6.12.7 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar -f <PATH_TO_VALUES>
+helm install --version 6.13.0 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>` is the name for the Helm release. It is recommended to re-use the same name you used for the initial deployment of the solution.
@@ -91,7 +91,7 @@ kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
 Upgrade the deployed components of the Sidecar solution:
 
 ``` bash
-helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-sidecar --version 6.12.7 -f <PATH_TO_VALUES>
+helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-sidecar --version 6.13.0 -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>`: the name of the Helm release with the deployed Sidecar chart
@@ -121,7 +121,7 @@ kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
 
     Where `wallarm-sidecar` is the namespace the Sidecar is deployed to. You can change this value if the namespace is different.
 
-    The chart version should correspond to `wallarm-sidecar-6.12.7`.
+    The chart version should correspond to `wallarm-sidecar-6.13.0`.
 1. Get the Wallarm control plane details to check it has been successfully started:
 
     ```bash

--- a/docs/6.x/user-guides/rules/rules.md
+++ b/docs/6.x/user-guides/rules/rules.md
@@ -301,12 +301,12 @@ To test a regular expression, use the Wallarm **cpire** utility. Install it via 
     1. Download the Wallarm all-in-one installer if it is not downloaded yet:
 
         ```
-        curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.x86_64-glibc.sh
+        curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.x86_64-glibc.sh
         ```
     1. Install the Wallarm modules if they are not installed yet:
         
         ```
-        sudo sh wallarm-6.12.7.x86_64-glibc.sh -- --batch --token <API_TOKEN>
+        sudo sh wallarm-6.13.0.x86_64-glibc.sh -- --batch --token <API_TOKEN>
         ```
     1. Run the **cpire** utility:
         
@@ -318,7 +318,7 @@ To test a regular expression, use the Wallarm **cpire** utility. Install it via 
     1. Run the **cpire** utility from the Wallarm Docker image:
     
         ```
-        docker run --rm -it wallarm/node:6.12.7 /opt/wallarm/usr/bin/cpire-runner -r '<YOUR_REGULAR_EXPRESSION>'
+        docker run --rm -it wallarm/node:6.13.0 /opt/wallarm/usr/bin/cpire-runner -r '<YOUR_REGULAR_EXPRESSION>'
         ```
     1. Enter the value to check whether it matches with the regular expression.
 

--- a/docs/latest/installation/heroku/docker-image.md
+++ b/docs/latest/installation/heroku/docker-image.md
@@ -339,7 +339,7 @@ To deploy Wallarm's Docker image on Heroku, start by creating the necessary conf
     ```dockerfile
     FROM ubuntu:22.04
 
-    ARG VERSION="6.12.7"
+    ARG VERSION="6.13.0"
 
     ENV PORT=3000
     ENV WALLARM_LABELS="group=heroku"
@@ -396,10 +396,10 @@ To deploy Wallarm's Docker image on Heroku, start by creating the necessary conf
 Execute the following commands within the previously created directory:
 
 ```
-docker build -t wallarm-heroku:6.12.7 .
+docker build -t wallarm-heroku:6.13.0 .
 docker login
-docker tag wallarm-heroku:6.12.7 <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.7
-docker push <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.7
+docker tag wallarm-heroku:6.13.0 <DOCKERHUB_USERNAME>/wallarm-heroku:6.13.0
+docker push <DOCKERHUB_USERNAME>/wallarm-heroku:6.13.0
 ```
 
 ## Step 3: Run the built Docker image on Heroku
@@ -410,7 +410,7 @@ To deploy the image on Heroku:
 1. Construct a `Dockerfile` which will include the installation of necessary dependencies specific to your app's runtime. For a Node.js application, use the following template:
 
     ```dockerfile
-    FROM <DOCKERHUB_USERNAME>/wallarm-heroku:6.12.7
+    FROM <DOCKERHUB_USERNAME>/wallarm-heroku:6.13.0
 
     ENV NODE_MAJOR=20
 

--- a/docs/latest/installation/kubernetes/sidecar-proxy/deployment.md
+++ b/docs/latest/installation/kubernetes/sidecar-proxy/deployment.md
@@ -104,7 +104,7 @@ Generate a filtering node token of the [appropriate type][node-token-types] to c
 1. Deploy the Wallarm Helm chart:
 
     ``` bash
-    helm install --version 6.12.7 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar --create-namespace -f <PATH_TO_VALUES>
+    helm install --version 6.13.0 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar --create-namespace -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name for the Helm release of the Wallarm Sidecar chart

--- a/docs/latest/installation/nginx-compatibility.md
+++ b/docs/latest/installation/nginx-compatibility.md
@@ -18,6 +18,7 @@ For the exact version added in a specific release, see the [NGINX Node changelog
 
 | Node version   | NGINX stable      | NGINX mainline    | NGINX Plus    |
 |----------------|-------------------|-------------------|---------------|
+| 6.13.0         | 1.30.4 and below  | 1.31.3 and below  | R37 and below |
 | 6.12.6–6.12.7  | 1.30.3 and below  | 1.31.2 and below  | R37 and below |
 | 6.12.5         | 1.30.2 and below  | 1.31.1 and below  | R37 and below |
 | 6.12.4         | 1.30.2 and below  | 1.31.1 and below  | R35 and below |

--- a/docs/latest/updating-migrating/sidecar-proxy.md
+++ b/docs/latest/updating-migrating/sidecar-proxy.md
@@ -29,7 +29,7 @@ To install and run the plugin:
 2. Run the plugin:
 
     ```bash
-    helm diff upgrade <RELEASE_NAME> -n wallarm-sidecar wallarm/wallarm-sidecar --version 6.12.7 -f <PATH_TO_VALUES>
+    helm diff upgrade <RELEASE_NAME> -n wallarm-sidecar wallarm/wallarm-sidecar --version 6.13.0 -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name of the Wallarm Sidecar Helm release.
@@ -64,7 +64,7 @@ kubectl delete secret <RELEASE_NAME>-wallarm-sidecar-admission-tls -n wallarm-si
 ### Step 5: Deploy the new solution version
 
 ``` bash
-helm install --version 6.12.7 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar -f <PATH_TO_VALUES>
+helm install --version 6.13.0 <RELEASE_NAME> wallarm/wallarm-sidecar --wait -n wallarm-sidecar -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>` is the name for the Helm release. It is recommended to re-use the same name you used for the initial deployment of the solution.
@@ -91,7 +91,7 @@ kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
 Upgrade the deployed components of the Sidecar solution:
 
 ``` bash
-helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-sidecar --version 6.12.7 -f <PATH_TO_VALUES>
+helm upgrade <RELEASE_NAME> -n <NAMESPACE> wallarm/wallarm-sidecar --version 6.13.0 -f <PATH_TO_VALUES>
 ```
 
 * `<RELEASE_NAME>`: the name of the Helm release with the deployed Sidecar chart
@@ -121,7 +121,7 @@ kubectl rollout restart deployment <DEPLOYMENT_NAME> -n <NAMESPACE>
 
     Where `wallarm-sidecar` is the namespace the Sidecar is deployed to. You can change this value if the namespace is different.
 
-    The chart version should correspond to `wallarm-sidecar-6.12.7`.
+    The chart version should correspond to `wallarm-sidecar-6.13.0`.
 1. Get the Wallarm control plane details to check it has been successfully started:
 
     ```bash

--- a/docs/latest/updating-migrating/what-is-new.md
+++ b/docs/latest/updating-migrating/what-is-new.md
@@ -312,11 +312,11 @@ The image configuration has moved from `controller.image` and `controller.wallar
       image:
         registry: <YOUR_REGISTRY>
         image: wallarm/ingress-controller
-        tag: "6.12.7"
+        tag: "6.13.0"
       wallarm:
         helpers:
           image: <YOUR_REGISTRY>/wallarm/node-helpers
-          tag: "6.12.7"
+          tag: "6.13.0"
     ```
 === "F5-based (7.x)"
     ```yaml

--- a/include/waf/installation/all-in-one-installer-download-6.x.md
+++ b/include/waf/installation/all-in-one-installer-download-6.x.md
@@ -7,9 +7,9 @@ To download all-in-one Wallarm installation script, execute the command:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.x86_64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.x86_64-glibc.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.aarch64-glibc.sh
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.aarch64-glibc.sh
     ```

--- a/include/waf/installation/all-in-one-installer-run-6.x.md
+++ b/include/waf/installation/all-in-one-installer-run-6.x.md
@@ -4,13 +4,13 @@
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh
         ```        
 
         The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -19,13 +19,13 @@
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.x86_64-glibc.sh
+        sudo sh wallarm-6.13.0.x86_64-glibc.sh
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-6.12.7.aarch64-glibc.sh
+        sudo sh wallarm-6.13.0.aarch64-glibc.sh
         ```
 
 1. Select [US Cloud](https://us1.my.wallarm.com/) or [EU Cloud](https://my.wallarm.com/).

--- a/include/waf/installation/all-in-one-nginx-latest.md
+++ b/include/waf/installation/all-in-one-nginx-latest.md
@@ -1,7 +1,7 @@
 Install the latest NGINX version of:
 
-* **NGINX `stable`** (the latest supported version is v1.30.3) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
-* **NGINX Mainline** (the latest supported version is v1.31.2) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
+* **NGINX `stable`** (the latest supported version is v1.30.4) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
+* **NGINX Mainline** (the latest supported version is v1.31.3) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
 * **NGINX Plus** (the latest supported version is NGINX Plus R37) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
 * **Distribution-Provided NGINX** - to install, use the following commands:
 

--- a/include/waf/installation/all-in-one-nginx-latest.md
+++ b/include/waf/installation/all-in-one-nginx-latest.md
@@ -1,7 +1,7 @@
 Install the latest NGINX version of:
 
-* **NGINX `stable`** (the latest supported version is v1.30.4) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
-* **NGINX Mainline** (the latest supported version is v1.31.3) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
+* **NGINX `stable`** (the latest supported version is v1.30.3) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
+* **NGINX Mainline** (the latest supported version is v1.31.2) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
 * **NGINX Plus** (the latest supported version is NGINX Plus R37) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
 * **Distribution-Provided NGINX** - to install, use the following commands:
 

--- a/include/waf/installation/all-in-one-postanalytics-6.x.md
+++ b/include/waf/installation/all-in-one-postanalytics-6.x.md
@@ -4,13 +4,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh postanalytics
     ```        
 
     The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -19,11 +19,11 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo sh wallarm-6.12.7.x86_64-glibc.sh postanalytics
+    sudo sh wallarm-6.13.0.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo sh wallarm-6.12.7.aarch64-glibc.sh postanalytics
+    sudo sh wallarm-6.13.0.aarch64-glibc.sh postanalytics
     ```

--- a/include/waf/installation/all-in-one/launch-options-6.x.md
+++ b/include/waf/installation/all-in-one/launch-options-6.x.md
@@ -1,7 +1,7 @@
 As soon as you have the all-in-one script downloaded, you can get help on it with:
 
 ```
-sudo sh ./wallarm-6.12.7.x86_64-glibc.sh -- -h
+sudo sh ./wallarm-6.13.0.x86_64-glibc.sh -- -h
 ```
 
 Which returns:
@@ -48,25 +48,25 @@ Below are examples of commands to run the script in batch mode for node installa
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh -- --batch -t <TOKEN> -c US
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh -- --batch -t <TOKEN> -c US
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh -- --batch -t <TOKEN> -c US
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh -- --batch -t <TOKEN> -c US
     ```
 === "EU Cloud"
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.x86_64-glibc.sh -- --batch -t <TOKEN>
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.x86_64-glibc.sh -- --batch -t <TOKEN>
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.12.7.aarch64-glibc.sh -- --batch -t <TOKEN>
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-6.13.0.aarch64-glibc.sh -- --batch -t <TOKEN>
     ```
 
 ### Separate execution of node installation stages
@@ -82,32 +82,32 @@ This functionality is supported starting from version 4.10.0 of the all-in-one i
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.x86_64-glibc.sh
-    sudo sh wallarm-6.12.7.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.x86_64-glibc.sh
+    sudo sh wallarm-6.13.0.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c US
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.aarch64-glibc.sh
-    sudo sh wallarm-6.12.7.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.aarch64-glibc.sh
+    sudo sh wallarm-6.13.0.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c US
     ```
 === "EU Cloud"
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.x86_64-glibc.sh
-    sudo sh wallarm-6.12.7.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.x86_64-glibc.sh
+    sudo sh wallarm-6.13.0.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN>
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/6.12/wallarm-6.12.7.aarch64-glibc.sh
-    sudo sh wallarm-6.12.7.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/6.13/wallarm-6.13.0.aarch64-glibc.sh
+    sudo sh wallarm-6.13.0.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN>
     ```
 Finally, to complete the installation, you need to [enable Wallarm to analyze traffic][enable-traffic-analysis-step] and [restart NGINX][restart-nginx-step].

--- a/include/waf/installation/cloud-platforms/reqs-and-steps-to-deploy-gcp-image-6.x.md
+++ b/include/waf/installation/cloud-platforms/reqs-and-steps-to-deploy-gcp-image-6.x.md
@@ -29,7 +29,7 @@ When using a tool like Terraform to launch the filtering node instance using Wal
 * To launch the instance with the filtering node version 6.x, please use the following image name:
 
     ```bash
-    wallarm-node-195710/wallarm-node-6-12-7-20260625-060642
+    wallarm-node-195710/wallarm-node-6-13-0-20260729-094623
     ```
 
 To get the image name, you can also follow these steps:
@@ -38,12 +38,12 @@ To get the image name, you can also follow these steps:
 2. Execute the command [`gcloud compute images list`](https://cloud.google.com/sdk/gcloud/reference/compute/images/list) with the following parameters:
 
     ```bash
-    gcloud compute images list --project wallarm-node-195710 --filter="name~'wallarm-node-6-12-*'" --no-standard-images
+    gcloud compute images list --project wallarm-node-195710 --filter="name~'wallarm-node-6-13-*'" --no-standard-images
     ```
 3. Copy the version value from the name of the latest available image and paste the copied value into the provided image name format. For example, the filtering node version 6.x image will have the following name:
 
     ```bash
-    wallarm-node-195710/wallarm-node-6-12-7-20260625-060642
+    wallarm-node-195710/wallarm-node-6-13-0-20260729-094623
     ```
 
 ## 2. Configure the filtering node instance


### PR DESCRIPTION
Add 6.13.0 (2026-07-29) changelog entries for the all-in-one installer, Ingress and Sidecar Helm charts, NGINX-based Docker image, AMI, and GCP image. The eBPF chart is versioned separately and gets no entry.

Documented changes:

* Added Server-Sent Events (SSE) analysis, improving MCP server discovery
* Improved DoS protection mitigation control accuracy
* Added support for NGINX stable 1.30.4 and mainline 1.31.3 (all-in-one only)
* Fixed CVE-2026-7246 and GHSA-6v7p-g79w-8964 (all-in-one and Docker image, both confirmed under /opt/wallarm)

Add the 6.13.0 row to the 6.x NGINX compatibility tables and bump 6.12.7 references to 6.13.0 across the 6.x docs and the 6.x include snippets, including the meganode path segment and the GCP image name.