### PR TITLE
Remove Azure Central US, West US 3, Germany West Central from SE deploy regions

### DIFF
--- a/docs/5.0/installation/security-edge/inline/deployment.md
+++ b/docs/5.0/installation/security-edge/inline/deployment.md
@@ -92,25 +92,10 @@ To restrict your origins to trusted traffic only, allow Edge Node connections us
 
         * Azure
 
-            === "Central US"
-                ```
-                104.43.139.76
-                104.43.139.77
-                ```
             === "East US 2"
                 ```
                 20.65.88.253
                 20.65.88.252
-                ```
-            === "West US 3"
-                ```
-                20.38.2.233
-                20.38.2.232
-                ```
-            === "Germany West Central"
-                ```
-                20.79.250.104
-                20.79.250.105
                 ```
             === "Switzerland North"
                 ```

--- a/docs/5.0/installation/security-edge/inline/multi-region.md
+++ b/docs/5.0/installation/security-edge/inline/multi-region.md
@@ -74,25 +74,10 @@ If mTLS cannot be used, allow incoming traffic from the Wallarm IP addresses of 
 
 * Azure
 
-    === "Central US"
-        ```
-        104.43.139.76
-        104.43.139.77
-        ```
     === "East US 2"
         ```
         20.65.88.253
         20.65.88.252
-        ```
-    === "West US 3"
-        ```
-        20.38.2.233
-        20.38.2.232
-        ```
-    === "Germany West Central"
-        ```
-        20.79.250.104
-        20.79.250.105
         ```
     === "Switzerland North"
         ```

--- a/docs/6.x/installation/security-edge/inline/deployment.md
+++ b/docs/6.x/installation/security-edge/inline/deployment.md
@@ -93,25 +93,10 @@ To restrict your origins to trusted traffic only, allow Edge Node connections us
 
         * Azure
 
-            === "Central US"
-                ```
-                104.43.139.76
-                104.43.139.77
-                ```
             === "East US 2"
                 ```
                 20.65.88.253
                 20.65.88.252
-                ```
-            === "West US 3"
-                ```
-                20.38.2.233
-                20.38.2.232
-                ```
-            === "Germany West Central"
-                ```
-                20.79.250.104
-                20.79.250.105
                 ```
             === "Switzerland North"
                 ```

--- a/docs/6.x/installation/security-edge/inline/multi-region.md
+++ b/docs/6.x/installation/security-edge/inline/multi-region.md
@@ -74,25 +74,10 @@ If mTLS cannot be used, allow incoming traffic from the Wallarm IP addresses of 
 
 * Azure
 
-    === "Central US"
-        ```
-        104.43.139.76
-        104.43.139.77
-        ```
     === "East US 2"
         ```
         20.65.88.253
         20.65.88.252
-        ```
-    === "West US 3"
-        ```
-        20.38.2.233
-        20.38.2.232
-        ```
-    === "Germany West Central"
-        ```
-        20.79.250.104
-        20.79.250.105
         ```
     === "Switzerland North"
         ```

--- a/docs/latest/installation/security-edge/inline/deployment.md
+++ b/docs/latest/installation/security-edge/inline/deployment.md
@@ -93,25 +93,10 @@ To restrict your origins to trusted traffic only, allow Edge Node connections us
 
         * Azure
 
-            === "Central US"
-                ```
-                104.43.139.76
-                104.43.139.77
-                ```
             === "East US 2"
                 ```
                 20.65.88.253
                 20.65.88.252
-                ```
-            === "West US 3"
-                ```
-                20.38.2.233
-                20.38.2.232
-                ```
-            === "Germany West Central"
-                ```
-                20.79.250.104
-                20.79.250.105
                 ```
             === "Switzerland North"
                 ```

--- a/docs/latest/installation/security-edge/inline/multi-region.md
+++ b/docs/latest/installation/security-edge/inline/multi-region.md
@@ -74,25 +74,10 @@ If mTLS cannot be used, allow incoming traffic from the Wallarm IP addresses of 
 
 * Azure
 
-    === "Central US"
-        ```
-        104.43.139.76
-        104.43.139.77
-        ```
     === "East US 2"
         ```
         20.65.88.253
         20.65.88.252
-        ```
-    === "West US 3"
-        ```
-        20.38.2.233
-        20.38.2.232
-        ```
-    === "Germany West Central"
-        ```
-        20.79.250.104
-        20.79.250.105
         ```
     === "Switzerland North"
         ```


### PR DESCRIPTION
## Summary
- Removed three Azure regions (Central US, West US 3, Germany West Central) from SecureEdge inline deployment documentation
- Applied across all doc versions: latest, 6.x, 5.0
- Remaining Azure regions: East US 2, Switzerland North, UAE North

## Test plan
- [ ] Verify rendered docs show only 3 Azure regions in IP ranges tabs
- [ ] Confirm no broken tab formatting in deployment.md and multi-region.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)