### PR TITLE
docs: add NGINX Node 7.1.1 and 7.1.2 release notes and bump versions

### DIFF
--- a/docs/latest/admin-en/chaining-wallarm-and-other-ingress-controllers.md
+++ b/docs/latest/admin-en/chaining-wallarm-and-other-ingress-controllers.md
@@ -104,7 +104,7 @@ To deploy the Wallarm Ingress controller and chain it with additional controller
     To learn more configuration options, please use the [link](configure-kubernetes-en.md).
 1. Install the Wallarm Ingress Helm chart:
     ``` bash
-    helm install --version 7.1.0 internal-ingress wallarm/wallarm-ingress -n wallarm-ingress -f values.yaml --create-namespace
+    helm install --version 7.1.2 internal-ingress wallarm/wallarm-ingress -n wallarm-ingress -f values.yaml --create-namespace
     ```
 
     * `internal-ingress` is the name of Helm release

--- a/docs/latest/admin-en/configure-wallarm-mode.md
+++ b/docs/latest/admin-en/configure-wallarm-mode.md
@@ -52,7 +52,7 @@ Note that the described configuration is applicable only for [in-line](../instal
     When deploying the NGINX-based Wallarm nodes via docker containers, [pass](../admin-en/installation-docker-en.md#run-the-container-passing-the-environment-variables) the `WALLARM_MODE` environment variable:
 
     ```
-    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_MODE='monitoring' -p 80:80 wallarm/node:7.1.0
+    docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -e WALLARM_MODE='monitoring' -p 80:80 wallarm/node:7.1.2
     ```
 
     Alternatively, [include](../admin-en/installation-docker-en.md#run-the-container-mounting-the-configuration-file) the corresponding parameter in the configuration file and run the container mounting this file.

--- a/docs/latest/admin-en/installation-docker-en.md
+++ b/docs/latest/admin-en/installation-docker-en.md
@@ -26,11 +26,11 @@ To run the container:
 
     === "US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:7.1.2
         ```
     === "EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND='example.com' -p 80:80 wallarm/node:7.1.2
         ```
 
 You can pass the following basic filtering node settings to the container via the option `-e`:
@@ -60,11 +60,11 @@ To run the container:
 
     === "US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:7.1.2
         ```
     === "EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN='XXXXXXX' -e WALLARM_LABELS='group=<GROUP>' -v /configs/default:/etc/nginx/http.d/default.conf -p 80:80 wallarm/node:7.1.2
         ```
 
     * The `-e` option passes the following required environment variables to the container:

--- a/docs/latest/admin-en/installation-kubernetes-en.md
+++ b/docs/latest/admin-en/installation-kubernetes-en.md
@@ -114,7 +114,7 @@ Generate a [Node API token][node-token-types]:
 1. Install the Wallarm packages:
 
     ```bash
-    helm install --version 7.1.0 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
+    helm install --version 7.1.2 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
     ```
 
     * `<RELEASE_NAME>` is the name for the Helm release of the Ingress controller chart

--- a/docs/latest/admin-en/installation-postanalytics-en.md
+++ b/docs/latest/admin-en/installation-postanalytics-en.md
@@ -30,11 +30,11 @@ To download all-in-one Wallarm installation script, execute the command:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.x86_64-glibc.sh
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.x86_64-glibc.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.aarch64-glibc.sh
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.aarch64-glibc.sh
     ```
 
 ## Step 2: Prepare Wallarm token
@@ -62,13 +62,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.x86_64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.aarch64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.aarch64-glibc.sh postanalytics
     ```        
 
     The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -77,13 +77,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo sh wallarm-7.1.0.x86_64-glibc.sh postanalytics
+    sudo sh wallarm-7.1.2.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo sh wallarm-7.1.0.aarch64-glibc.sh postanalytics
+    sudo sh wallarm-7.1.2.aarch64-glibc.sh postanalytics
     ```
 
 ## Step 4: Configure the postanalytics module
@@ -167,13 +167,13 @@ Once the postanalytics module is installed on the separate server:
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.x86_64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.aarch64-glibc.sh filtering
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.aarch64-glibc.sh filtering
         ```        
 
         The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -182,13 +182,13 @@ Once the postanalytics module is installed on the separate server:
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-7.1.0.x86_64-glibc.sh filtering
+        sudo sh wallarm-7.1.2.x86_64-glibc.sh filtering
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-7.1.0.aarch64-glibc.sh filtering
+        sudo sh wallarm-7.1.2.aarch64-glibc.sh filtering
         ```
 
 ## Step 8: Connect the NGINX-Wallarm module to the postanalytics module

--- a/docs/latest/installation/cloud-platforms/alibaba-cloud/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/alibaba-cloud/docker-container.md
@@ -44,11 +44,11 @@ To deploy the containerized Wallarm filtering node configured only through envir
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -e WALLARM_API_HOST='us1.api.wallarm.com' -p 80:80 wallarm/node:7.1.2
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> -p 80:80 wallarm/node:7.1.2
         ```
         
     * `-p`: port the filtering node listens to. The value should be the same as the instance port.
@@ -108,11 +108,11 @@ To deploy the containerized Wallarm filtering node configured through environmen
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.2
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.2
         ```
 
     * `<INSTANCE_PATH_TO_CONFIG>`: path to the configuration file created in the previous step. For example, `configs`.

--- a/docs/latest/installation/cloud-platforms/aws/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/aws/docker-container.md
@@ -123,7 +123,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:7.1.0"
+                "image": "registry-1.docker.io/wallarm/node:7.1.2"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -161,7 +161,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:7.1.0"
+                "image": "registry-1.docker.io/wallarm/node:7.1.2"
                 }
             ],
             "family": "wallarm-api-security-node"
@@ -296,7 +296,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:7.1.0"
+                "image": "registry-1.docker.io/wallarm/node:7.1.2"
                 }
             ],
             "volumes": [
@@ -345,7 +345,7 @@ To deploy the container with environment variables and configuration file mounte
                     }
                 ],
                 "name": "wallarm-container",
-                "image": "registry-1.docker.io/wallarm/node:7.1.0"
+                "image": "registry-1.docker.io/wallarm/node:7.1.2"
                 }
             ],
             "volumes": [
@@ -442,7 +442,7 @@ To avoid this, authenticate ECS tasks to Docker Hub using a paid Docker Hub acco
     "containerDefinitions": [
         {
             "name": "wallarm-container",
-            "image": "registry-1.docker.io/wallarm/node:7.1.0",
+            "image": "registry-1.docker.io/wallarm/node:7.1.2",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:<DOCKER_HUB_SECRET_NAME>"
             },

--- a/docs/latest/installation/cloud-platforms/azure/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/azure/docker-container.md
@@ -60,7 +60,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:7.1.0 \
+            --image registry-1.docker.io/wallarm/node:7.1.2 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_API_HOST='us1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
          ```
     === "Command for the Wallarm EU Cloud"
@@ -70,7 +70,7 @@ In these instructions, the container is deployed using the Azure CLI.
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:7.1.0 \
+            --image registry-1.docker.io/wallarm/node:7.1.2 \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} NGINX_BACKEND='example.com' WALLARM_LABELS='group=<GROUP>'
          ```
 
@@ -148,7 +148,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:7.1.0 \
+            --image registry-1.docker.io/wallarm/node:7.1.2 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_API_HOST='us1.api.wallarm.com' WALLARM_LABELS='group=<GROUP>'
@@ -160,7 +160,7 @@ To deploy the container with environment variables and mounted configuration fil
             --name wallarm-node \
             --dns-name-label wallarm \
             --ports 80 \
-            --image registry-1.docker.io/wallarm/node:7.1.0 \
+            --image registry-1.docker.io/wallarm/node:7.1.2 \
             --gitrepo-url <URL_OF_GITREPO> \
             --gitrepo-mount-path /etc/nginx/http.d \
             --environment-variables WALLARM_API_TOKEN=${WALLARM_API_TOKEN} WALLARM_LABELS='group=<GROUP>'

--- a/docs/latest/installation/cloud-platforms/gcp/docker-container.md
+++ b/docs/latest/installation/cloud-platforms/gcp/docker-container.md
@@ -45,7 +45,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
             --container-env WALLARM_API_HOST=us1.api.wallarm.com \
-            --container-image registry-1.docker.io/wallarm/node:7.1.0
+            --container-image registry-1.docker.io/wallarm/node:7.1.2
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
@@ -54,7 +54,7 @@ To deploy the containerized Wallarm filtering node configured only through envir
             --tags http-server \
             --container-env WALLARM_API_TOKEN=${WALLARM_API_TOKEN} \
             --container-env NGINX_BACKEND=<HOST_TO_PROTECT_WITH_WALLARM> \
-            --container-image registry-1.docker.io/wallarm/node:7.1.0
+            --container-image registry-1.docker.io/wallarm/node:7.1.2
         ```
 
     * `<INSTANCE_NAME>`: name of the instance, for example: `wallarm-node`.
@@ -129,11 +129,11 @@ To deploy the containerized Wallarm filtering node configured through environmen
 
     === "Command for the Wallarm US Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -e WALLARM_API_HOST='us1.api.wallarm.com' -v <INSTANCE_PATH_TO_CONFIG>:<DIRECTORY_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.2
         ```
     === "Command for the Wallarm EU Cloud"
         ```bash
-        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.0
+        docker run -d -e WALLARM_API_TOKEN=${WALLARM_API_TOKEN} -e WALLARM_LABELS='group=<GROUP>' -v <INSTANCE_PATH_TO_CONFIG>:<CONTAINER_PATH_FOR_MOUNTING> -p 80:80 wallarm/node:7.1.2
         ```
 
     * `<INSTANCE_PATH_TO_CONFIG>`: path to the configuration file created in the previous step. For example, `configs`.

--- a/docs/latest/installation/nginx-compatibility.md
+++ b/docs/latest/installation/nginx-compatibility.md
@@ -12,7 +12,8 @@ For the exact version added in a specific release, see the [NGINX Node changelog
 
 | Node version   | NGINX stable      | NGINX mainline    | NGINX Plus    |
 |----------------|-------------------|-------------------|---------------|
-| 7.1.0 and above| 1.30.3 and below  | 1.31.2 and below  | R37 and below |
+| 7.1.2 and above| 1.30.4 and below  | 1.31.4 and below  | R37 and below |
+| 7.1.0–7.1.1    | 1.30.3 and below  | 1.31.2 and below  | R37 and below |
 
 ### NGINX Node 6.x
 

--- a/docs/latest/updating-migrating/docker-container.md
+++ b/docs/latest/updating-migrating/docker-container.md
@@ -29,7 +29,7 @@ These instructions describe the steps to upgrade the running Docker NGINX-based 
 ## Step 1: Download the updated filtering node image
 
 ``` bash
-docker pull wallarm/node:7.1.0
+docker pull wallarm/node:7.1.2
 ```
 
 ## Step 2: Stop the running container

--- a/docs/latest/updating-migrating/ingress-controller.md
+++ b/docs/latest/updating-migrating/ingress-controller.md
@@ -177,7 +177,7 @@ Before starting the migration, gather the following information from your existi
 
     # Deploy the new Ingress Controller
     helm install wallarm-ingress-new wallarm/wallarm-ingress \
-      --version 7.1.0 \
+      --version 7.1.2 \
       -n wallarm-ingress-new \
       --create-namespace \
       -f values.yaml
@@ -562,7 +562,7 @@ This method preserves the existing load balancer IP by switching the Kubernetes 
 
     ```bash
     helm install wallarm-ingress-new wallarm/wallarm-ingress \
-      --version 7.1.0 \
+      --version 7.1.2 \
       -n <CURRENT_IC_NAMESPACE> \
       -f values-same-namespace.yaml
     ```
@@ -847,7 +847,7 @@ This method removes the old controller and deploys the new one in its place.
 
     ```bash
     helm install wallarm-ingress wallarm/wallarm-ingress \
-      --version 7.1.0 \
+      --version 7.1.2 \
       -n wallarm-ingress \
       --create-namespace \
       -f new-values.yaml

--- a/docs/latest/updating-migrating/node-artifact-versions.md
+++ b/docs/latest/updating-migrating/node-artifact-versions.md
@@ -10,6 +10,25 @@ History of all-in-one installer updates simultaneously applies to its x86_64 and
 
 [How to migrate from previous all-in-one installer version](all-in-one.md)
 
+### 7.1.2 (2026-08-20)
+
+* Added support for NGINX stable 1.30.4
+* Added support for NGINX mainline 1.31.4
+* Fixed a 7.1.1 regression that silently dropped some requests from the export pipeline under burst load — the affected attacks and sessions never reached the Wallarm Cloud
+* Bumped Go version to 1.26.7
+* Fixed security vulnerabilities:
+
+    * [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821)
+    * [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
+    * [CVE-2026-56859](https://nvd.nist.gov/vuln/detail/CVE-2026-56859)
+    * [CVE-2026-56853](https://nvd.nist.gov/vuln/detail/CVE-2026-56853)
+    * [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600)
+    * [CVE-2026-33818](https://nvd.nist.gov/vuln/detail/CVE-2026-33818)
+
+### 7.1.1 (2026-08-07)
+
+* Fixed the Wallarm NGINX module reporting `ngx_add_event(eventfd) failed` and `epoll_ctl ... Bad file descriptor` errors in the NGINX error log
+
 ### 7.1.0 (2026-07-21)
 
 * Added the ability for the node to [start when the Wallarm Cloud is temporarily unavailable](../faq/wallarm-cloud-down.md#can-a-wallarm-node-start-while-the-cloud-is-down)
@@ -30,6 +49,17 @@ History of all-in-one installer updates simultaneously applies to its x86_64 and
 ## Helm chart for Wallarm NGINX Ingress controller
 
 [How to upgrade](ingress-controller.md)
+
+### 7.1.2 (2026-08-20)
+
+* Fixed a 7.1.1 regression that silently dropped some requests from the export pipeline under burst load — the affected attacks and sessions never reached the Wallarm Cloud
+
+### 7.1.1 (2026-08-07)
+
+* Fixed the Wallarm NGINX module reporting `ngx_add_event(eventfd) failed` and `epoll_ctl ... Bad file descriptor` errors in the NGINX error log
+* Fixed security vulnerabilities:
+
+    * [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf)
 
 ### 7.1.0 (2026-07-21)
 
@@ -74,6 +104,23 @@ History of all-in-one installer updates simultaneously applies to its x86_64 and
 
 [How to upgrade](docker-container.md)
 
+### 7.1.2 (2026-08-20)
+
+* Fixed a 7.1.1 regression that silently dropped some requests from the export pipeline under burst load — the affected attacks and sessions never reached the Wallarm Cloud
+* Bumped Go version to 1.26.7
+* Fixed security vulnerabilities:
+
+    * [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821)
+    * [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
+    * [CVE-2026-56859](https://nvd.nist.gov/vuln/detail/CVE-2026-56859)
+    * [CVE-2026-56853](https://nvd.nist.gov/vuln/detail/CVE-2026-56853)
+    * [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600)
+    * [CVE-2026-33818](https://nvd.nist.gov/vuln/detail/CVE-2026-33818)
+
+### 7.1.1 (2026-08-07)
+
+* Fixed the Wallarm NGINX module reporting `ngx_add_event(eventfd) failed` and `epoll_ctl ... Bad file descriptor` errors in the NGINX error log
+
 ### 7.1.0 (2026-07-21)
 
 * Removed the `appstructure` component (the [API Discovery](../api-discovery/overview.md) module), including its `appstructure-out.log` log
@@ -94,6 +141,19 @@ History of all-in-one installer updates simultaneously applies to its x86_64 and
 
 [How to upgrade](cloud-image.md)
 
+### 7.1.2 (2026-08-20)
+
+* Fixed a 7.1.1 regression that silently dropped some requests from the export pipeline under burst load — the affected attacks and sessions never reached the Wallarm Cloud
+* Bumped Go version to 1.26.7
+* Fixed security vulnerabilities:
+
+    * [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821)
+    * [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
+    * [CVE-2026-56859](https://nvd.nist.gov/vuln/detail/CVE-2026-56859)
+    * [CVE-2026-56853](https://nvd.nist.gov/vuln/detail/CVE-2026-56853)
+    * [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600)
+    * [CVE-2026-33818](https://nvd.nist.gov/vuln/detail/CVE-2026-33818)
+
 ### 7.1.0 (2026-07-21)
 
 * Added the ability for the node to [start even when the Wallarm Cloud is temporarily unavailable](../faq/wallarm-cloud-down.md#can-a-wallarm-node-start-while-the-cloud-is-down)
@@ -112,6 +172,23 @@ History of all-in-one installer updates simultaneously applies to its x86_64 and
 ## Google Cloud Platform Image
 
 [How to upgrade](cloud-image.md)
+
+### wallarm-node-7-1-2-20260820-142512 (2026-08-20)
+
+* Fixed a 7.1.1 regression that silently dropped some requests from the export pipeline under burst load — the affected attacks and sessions never reached the Wallarm Cloud
+* Bumped Go version to 1.26.7
+* Fixed security vulnerabilities:
+
+    * [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821)
+    * [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
+    * [CVE-2026-56859](https://nvd.nist.gov/vuln/detail/CVE-2026-56859)
+    * [CVE-2026-56853](https://nvd.nist.gov/vuln/detail/CVE-2026-56853)
+    * [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600)
+    * [CVE-2026-33818](https://nvd.nist.gov/vuln/detail/CVE-2026-33818)
+
+### wallarm-node-7-1-1-20260807-170213 (2026-08-07)
+
+* Fixed the Wallarm NGINX module reporting `ngx_add_event(eventfd) failed` and `epoll_ctl ... Bad file descriptor` errors in the NGINX error log
 
 ### wallarm-node-7-1-0-20260722-105251 (2026-07-22)
 

--- a/docs/latest/updating-migrating/what-is-new.md
+++ b/docs/latest/updating-migrating/what-is-new.md
@@ -324,11 +324,11 @@ The image configuration has moved from `controller.image` and `controller.wallar
       images:
         controller:
           repository: "<YOUR_REGISTRY>/wallarm/ingress-controller"
-          tag: "7.1.0"
+          tag: "7.1.2"
           pullPolicy: IfNotPresent
         helper:
           repository: "<YOUR_REGISTRY>/wallarm/node-helpers"
-          tag: "7.1.0"
+          tag: "7.1.2"
           pullPolicy: IfNotPresent
     ```
 
@@ -405,7 +405,7 @@ Minimal steps:
     ```
 
 ```bash
-helm install --version 7.1.0 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
+helm install --version 7.1.2 <RELEASE_NAME> wallarm/wallarm-ingress -n <KUBERNETES_NAMESPACE> -f <PATH_TO_VALUES>
 ```
 
 For the full installation guide, see [Deploying Wallarm Ingress Controller](../admin-en/installation-kubernetes-en.md).

--- a/docs/latest/user-guides/rules/rules.md
+++ b/docs/latest/user-guides/rules/rules.md
@@ -301,12 +301,12 @@ To test a regular expression, use the Wallarm **cpire** utility. Install it via 
     1. Download the Wallarm all-in-one installer if it is not downloaded yet:
 
         ```
-        curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.x86_64-glibc.sh
+        curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.x86_64-glibc.sh
         ```
     1. Install the Wallarm modules if they are not installed yet:
         
         ```
-        sudo sh wallarm-7.1.0.x86_64-glibc.sh -- --batch --token <API_TOKEN>
+        sudo sh wallarm-7.1.2.x86_64-glibc.sh -- --batch --token <API_TOKEN>
         ```
     1. Run the **cpire** utility:
         
@@ -318,7 +318,7 @@ To test a regular expression, use the Wallarm **cpire** utility. Install it via 
     1. Run the **cpire** utility from the Wallarm Docker image:
     
         ```
-        docker run --rm -it wallarm/node:7.1.0 /opt/wallarm/usr/bin/cpire-runner -r '<YOUR_REGULAR_EXPRESSION>'
+        docker run --rm -it wallarm/node:7.1.2 /opt/wallarm/usr/bin/cpire-runner -r '<YOUR_REGULAR_EXPRESSION>'
         ```
     1. Enter the value to check whether it matches with the regular expression.
 

--- a/include/waf/installation/all-in-one-installer-download.md
+++ b/include/waf/installation/all-in-one-installer-download.md
@@ -7,9 +7,9 @@ To download all-in-one Wallarm installation script, execute the command:
 
 === "x86_64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.x86_64-glibc.sh
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.x86_64-glibc.sh
     ```
 === "ARM64 version"
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.aarch64-glibc.sh
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.aarch64-glibc.sh
     ```

--- a/include/waf/installation/all-in-one-installer-run.md
+++ b/include/waf/installation/all-in-one-installer-run.md
@@ -4,13 +4,13 @@
         If using the x86_64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.x86_64-glibc.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.x86_64-glibc.sh
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.aarch64-glibc.sh
+        sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.aarch64-glibc.sh
         ```        
 
         The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -19,13 +19,13 @@
         If using the x86_64 version:
 
         ```bash
-        sudo sh wallarm-7.1.0.x86_64-glibc.sh
+        sudo sh wallarm-7.1.2.x86_64-glibc.sh
         ```
 
         If using the ARM64 version:
 
         ```bash
-        sudo sh wallarm-7.1.0.aarch64-glibc.sh
+        sudo sh wallarm-7.1.2.aarch64-glibc.sh
         ```
 
 1. Select [US Cloud](https://us1.my.wallarm.com/) or [EU Cloud](https://my.wallarm.com/).

--- a/include/waf/installation/all-in-one-nginx-latest.md
+++ b/include/waf/installation/all-in-one-nginx-latest.md
@@ -1,7 +1,7 @@
 Install the latest NGINX version of:
 
-* **NGINX `stable`** (the latest supported version is v1.30.3) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
-* **NGINX Mainline** (the latest supported version is v1.31.2) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
+* **NGINX `stable`** (the latest supported version is v1.30.4) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
+* **NGINX Mainline** (the latest supported version is v1.31.4) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/).
 * **NGINX Plus** (the latest supported version is NGINX Plus R37) - see how to install it in the NGINX [documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
 * **Distribution-Provided NGINX** - to install, use the following commands:
 

--- a/include/waf/installation/all-in-one-postanalytics.md
+++ b/include/waf/installation/all-in-one-postanalytics.md
@@ -4,13 +4,13 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.x86_64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.aarch64-glibc.sh postanalytics
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.aarch64-glibc.sh postanalytics
     ```        
 
     The `WALLARM_LABELS` variable sets the group into which the node will be added (used for logical grouping of nodes in the Wallarm Console UI).
@@ -19,11 +19,11 @@ To install postanalytics separately with all-in-one installer, use:
     If using the x86_64 version:
 
     ```bash
-    sudo sh wallarm-7.1.0.x86_64-glibc.sh postanalytics
+    sudo sh wallarm-7.1.2.x86_64-glibc.sh postanalytics
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo sh wallarm-7.1.0.aarch64-glibc.sh postanalytics
+    sudo sh wallarm-7.1.2.aarch64-glibc.sh postanalytics
     ```

--- a/include/waf/installation/all-in-one/launch-options.md
+++ b/include/waf/installation/all-in-one/launch-options.md
@@ -1,7 +1,7 @@
 As soon as you have the all-in-one script downloaded, you can get help on it with:
 
 ```
-sudo sh ./wallarm-7.1.0.x86_64-glibc.sh -- -h
+sudo sh ./wallarm-7.1.2.x86_64-glibc.sh -- -h
 ```
 
 Which returns:
@@ -48,25 +48,25 @@ Below are examples of commands to run the script in batch mode for node installa
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.x86_64-glibc.sh -- --batch -t <TOKEN> -c US
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.x86_64-glibc.sh -- --batch -t <TOKEN> -c US
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.aarch64-glibc.sh -- --batch -t <TOKEN> -c US
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.aarch64-glibc.sh -- --batch -t <TOKEN> -c US
     ```
 === "EU Cloud"
     If using the x86_64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.x86_64-glibc.sh -- --batch -t <TOKEN>
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.x86_64-glibc.sh -- --batch -t <TOKEN>
     ```
 
     If using the ARM64 version:
 
     ```bash
-    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.0.aarch64-glibc.sh -- --batch -t <TOKEN>
+    sudo env WALLARM_LABELS='group=<GROUP>' sh wallarm-7.1.2.aarch64-glibc.sh -- --batch -t <TOKEN>
     ```
 
 ### Separate execution of node installation stages
@@ -82,32 +82,32 @@ This functionality is supported starting from version 4.10.0 of the all-in-one i
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.x86_64-glibc.sh
-    sudo sh wallarm-7.1.0.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.x86_64-glibc.sh
+    sudo sh wallarm-7.1.2.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c US
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.aarch64-glibc.sh
-    sudo sh wallarm-7.1.0.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.aarch64-glibc.sh
+    sudo sh wallarm-7.1.2.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN> -c US
     ```
 === "EU Cloud"
     If using the x86_64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.x86_64-glibc.sh
-    sudo sh wallarm-7.1.0.x86_64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.x86_64-glibc.sh
+    sudo sh wallarm-7.1.2.x86_64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN>
     ```
 
     If using the ARM64 version:
 
     ```bash
-    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.0.aarch64-glibc.sh
-    sudo sh wallarm-7.1.0.aarch64-glibc.sh -- --batch --install-only
+    curl -O https://meganode.wallarm.com/7.1/wallarm-7.1.2.aarch64-glibc.sh
+    sudo sh wallarm-7.1.2.aarch64-glibc.sh -- --batch --install-only
     sudo env WALLARM_LABELS='group=<GROUP>' /opt/wallarm/setup.sh --batch --register-only -t <TOKEN>
     ```
 Finally, to complete the installation, you need to [enable Wallarm to analyze traffic][enable-traffic-analysis-step] and [restart NGINX][restart-nginx-step].

--- a/include/waf/installation/cloud-platforms/reqs-and-steps-to-deploy-gcp-image.md
+++ b/include/waf/installation/cloud-platforms/reqs-and-steps-to-deploy-gcp-image.md
@@ -29,7 +29,7 @@ When using a tool like Terraform to launch the filtering node instance using Wal
 * To launch the instance with the filtering node version 7.x, please use the following image name:
 
     ```bash
-    wallarm-node-195710/wallarm-node-7-1-0-20260722-105251
+    wallarm-node-195710/wallarm-node-7-1-2-20260820-142512
     ```
 
 To get the image name, you can also follow these steps:
@@ -43,7 +43,7 @@ To get the image name, you can also follow these steps:
 3. Copy the version value from the name of the latest available image and paste the copied value into the provided image name format. For example, the filtering node version 7.x image will have the following name:
 
     ```bash
-    wallarm-node-195710/wallarm-node-7-1-0-20260722-105251
+    wallarm-node-195710/wallarm-node-7-1-2-20260820-142512
     ```
 
 ## 2. Configure the filtering node instance


### PR DESCRIPTION
Add 7.1.2 (2026-08-20) and 7.1.1 (2026-08-07) changelog entries to the 7.x line for the all-in-one installer, the Ingress Helm chart, the NGINX-based Docker image, the AMI, and the GCP image. 7.1.1 had shipped across every form factor without ever being documented, so it gets its own entry rather than being folded into 7.1.2.

Documented changes:

* 7.1.1: fixed the Wallarm NGINX module reporting ngx_add_event(eventfd) and epoll_ctl errors in the NGINX error log; GHSA-hrxh-6v49-42gf on the Ingress chart
* 7.1.2: added support for NGINX stable 1.30.4 and mainline 1.31.4 (all-in-one only), fixed a 7.1.1 regression that silently dropped requests from the export pipeline under burst load, bumped Go to 1.26.7, and fixed six HIGH/CRITICAL CVEs (all confirmed under /opt/wallarm)

CVE lists come from per-artifact docker scout compare runs. The Ingress chart carries its own list; the Go bump is omitted there because that image's Go stdlib did not change. CVE-2026-46600 is listed only under 7.1.2 because it remained reachable via stdlib in 7.1.1.

Add the 7.1.2 row to the 7.x NGINX compatibility table, rebound the previous row to 7.1.0-7.1.1, and bump 7.1.0 references to 7.1.2 across docs/latest and the 7.x include snippets, including the GCP image name. Version-introduction statements ("Starting from NGINX Node 7.1.0") are preserved.